### PR TITLE
Took Locality Search fix

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -164,16 +164,15 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 					$tempTermArr[] = 'Locality IS NULL';
 				}
 				else{
-					$fullTextSearch = true;
-					if(strlen($value) < 4) $fullTextSearch = false;
-					elseif(strpos($value,' ')){
-						$wordArr = explode(' ',$value);
-						$fullTextSearch = false;
-						foreach($wordArr as $w){
-							if(strlen($w) > 3){
-								$fullTextSearch = true;
-								break;
-							}
+					$wordArr = explode(' ',$value);
+					$fullTextSearch = false;
+					foreach($wordArr as $w){
+						if(strlen($w) > 3){
+							$fullTextSearch = true;
+						}
+						if(in_array(strtolower($w),array('took'))){
+							$fullTextSearch = false;
+							break;
 						}
 					}
 					if($fullTextSearch) $fullTextArr[] = $this->cleanInStr(str_replace('"', '', $value));
@@ -265,7 +264,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 			else{
 				$fullCollArr = array();
 				foreach($collectorArr AS $collStr){
-					if(strlen($collStr) == 2 || strlen($collStr) == 3 || in_array(strtolower($collStr),array('best','little','took'))){
+					if(strlen($collStr) == 2 || strlen($collStr) == 3 || in_array(strtolower($collStr),array('best','little'))){
 						//Need to avoid FULLTEXT stopwords interfering with return
 						$tempCollSqlArr[] = '(o.recordedBy LIKE "%'.$this->cleanInStr($collStr).'%")';
 						$tempCollTextArr[] = $collStr;

--- a/classes/OccurrenceSupport.php
+++ b/classes/OccurrenceSupport.php
@@ -127,7 +127,7 @@ class OccurrenceSupport {
 		if($catalogNumber) $sqlWhere .= 'AND (o.catalognumber = "'.$catalogNumber.'") ';
 		if($otherCatalogNumbers) $sqlWhere .= 'AND (o.othercatalognumbers = "'.$otherCatalogNumbers.'" OR i.identifiervalue = "'.$otherCatalogNumbers.'") ';
 		if($recordedBy){
-			if(strlen($recordedBy) < 4 || in_array(strtolower($recordedBy),array('best','little','took'))){
+			if(strlen($recordedBy) < 4 || in_array(strtolower($recordedBy),array('best','little'))){
 				//Need to avoid FULLTEXT stopwords interfering with return
 				$sqlWhere .= 'AND (o.recordedby LIKE "%'.$recordedBy.'%") ';
 			}


### PR DESCRIPTION
- Skip Fulltext searches when "took" is included as a locality search term. "took" is a MyISAM stopword.
- Ignore alterations made within OccurrenceSupport.php file, which is walk back of a previous, unsuccessful modification 
