### PR TITLE
Parentheses issue in CoL API

### DIFF
--- a/classes/TaxonomyHarvester.php
+++ b/classes/TaxonomyHarvester.php
@@ -167,6 +167,10 @@ class TaxonomyHarvester extends Manager{
 						if(mb_strpos($cbNameUsage['name']['scientificName'], '×') !== false){
 							if(in_array(trim(str_replace(array('× ','×'), '', $cbNameUsage['name']['scientificName'])), $inputTestArr)) $isNotSimilar = false;
 						}
+						if (strpos($cbNameUsage['name']['scientificName'], '(') !== false) {
+							$cleanedName = preg_replace('/ \([^)]+\)/', '', $cbNameUsage['name']['scientificName']);
+							if (in_array(trim($cleanedName), $inputTestArr)) $isNotSimilar = false;
+						}
 						if(mb_strpos($cbNameUsage['name']['scientificName'], '†') !== false){
 							if(in_array(trim(str_replace(array('† ','†'), '', $cbNameUsage['name']['scientificName'])), $inputTestArr)) $isNotSimilar = false;
 						}


### PR DESCRIPTION
Fixes issue where the result from the CoL API has the subgenus name in parenthesis in the species name. Code was originally considering these to be incorrectly separate taxa and not ingesting.