### PR TITLE
Occurrence Harvester taxonomy adjustment

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -95,7 +95,6 @@ class OccurrenceHarvester{
 		if($sqlWhere){
 			$this->setStateArr();
 			$this->setDomainSiteArr();
-			$this->protectCuratorAnnotations();
 			//if(!$this->setSampleClassArr()) echo '<li>'.$this->errorStr.'</li>';
 			echo '<li>Target record count: '.number_format($this->getTargetCount($sqlWhere)).'</li>';
 			$collArr = array();
@@ -189,13 +188,6 @@ class OccurrenceHarvester{
 			}
 		}
 		return false;
-	}
-
-	private function protectCuratorAnnotations(){
-		//Temporary code needed until until db patch 1.3 is officialize and annoator edits saved
-		$this->conn->query('UPDATE omoccurdeterminations SET enteredByUid = 16 WHERE identifiedBy LIKE "%Laura% Steger%" AND enteredByUid IS NULL');
-		$this->conn->query('UPDATE omoccurdeterminations SET enteredByUid = 3 WHERE identifiedBy LIKE "%Andrew Johnston%" AND enteredByUid IS NULL');
-		$this->conn->query('UPDATE omoccurdeterminations SET enteredByUid = 56 WHERE identifiedBy LIKE "R% Liao" AND enteredByUid IS NULL');
 	}
 
 	private function getTargetCount($sqlWhere){
@@ -485,7 +477,16 @@ class OccurrenceHarvester{
 								$identArr['sciname'] = $fArr['smsValue'];
 								$identArr['taxon'] = $fArr['smsValue'];
 							}
-							elseif($fArr['smsKey'] == 'taxon_published' && $fArr['smsValue']) $identArr['taxonPublished'] = $fArr['smsValue'];
+							elseif($fArr['smsKey'] == 'taxon_published' && $fArr['smsValue']){
+								//Temporarly keep to support possibility of this field still being used for certain sampleClasses
+								$identArr['taxonPublished'] = $fArr['smsValue'];
+							}
+							elseif($fArr['smsKey'] == 'taxon_published_processed_scientific_name' && $fArr['smsValue']){
+								$identArr['taxonPublished'] = $fArr['smsValue'];
+							}
+							elseif($fArr['smsKey'] == 'taxon_published_processed_code' && $fArr['smsValue']){
+								$identArr['taxonPublishedCode'] = $fArr['smsValue'];
+							}
 							elseif($fArr['smsKey'] == 'identified_by' && $fArr['smsValue']) $identArr['identifiedBy'] = $this->translatePersonnel($fArr['smsValue']);
 							elseif($fArr['smsKey'] == 'identified_date' && $fArr['smsValue']) $identArr['dateIdentified'] = $fArr['smsValue'];
 							elseif($fArr['smsKey'] == 'identification_remarks' && $fArr['smsValue']) $identArr['identificationRemarks'] = $fArr['smsValue'];
@@ -1528,7 +1529,7 @@ class OccurrenceHarvester{
 			12 => 'HERPETOLOGY', 15 => 'HERPETOLOGY', 70 => 'HERPETOLOGY',
 			21 => 'MACROINVERTEBRATE', 22 => 'MACROINVERTEBRATE', 45 => 'MACROINVERTEBRATE', 48 => 'MACROINVERTEBRATE', 52 => 'MACROINVERTEBRATE', 53 => 'MACROINVERTEBRATE', 55 => 'MACROINVERTEBRATE', 57 => 'MACROINVERTEBRATE', 60 => 'MACROINVERTEBRATE', 61 => 'MACROINVERTEBRATE', 62 => 'MACROINVERTEBRATE', 84 => 'MACROINVERTEBRATE',
 			29 => 'MOSQUITO', 56 => 'MOSQUITO', 58 => 'MOSQUITO', 59 => 'MOSQUITO', 65 => 'MOSQUITO',
-			7 => 'PLANT', 8 => 'PLANT', 9 => 'PLANT', 18 => 'PLANT', 40 => 'PLANT', 54 => 'PLANT', 
+			7 => 'PLANT', 8 => 'PLANT', 9 => 'PLANT', 18 => 'PLANT', 40 => 'PLANT', 54 => 'PLANT',
 			17 => 'SMALL_MAMMAL', 19 => 'SMALL_MAMMAL', 24 => 'SMALL_MAMMAL', 25 => 'SMALL_MAMMAL', 26 => 'SMALL_MAMMAL', 27 => 'SMALL_MAMMAL', 28 => 'SMALL_MAMMAL', 64 => 'SMALL_MAMMAL', 71 => 'SMALL_MAMMAL', 74 => 'SMALL_MAMMAL', 90 => 'SMALL_MAMMAL', 91 => 'SMALL_MAMMAL',
 			30 => 'SOIL', 79 => 'SOIL', 80 =>'SOIL',
 			75 => 'TICK', 83 => 'TICK'


### PR DESCRIPTION
- Adjust sms taxonomy terms to match NEON API output modification
- Remove code that makes sure that curator annotations are properly tagged as so, which is no longer needed due to annotation tracking being built directly into the model

