### PR TITLE
Removes x fuzzy matching

### DIFF
--- a/classes/TaxonomyCleaner.php
+++ b/classes/TaxonomyCleaner.php
@@ -154,7 +154,7 @@ class TaxonomyCleaner extends Manager{
 					$this->logOrEcho($manStr,2);
 				}
 				$taxaCnt++;
-				$endIndex = preg_replace("/[^A-Za-z\-. ]/", "", $r->sciname );
+				$endIndex = preg_replace("/[^A-Za-z\-. ×]/", "", $r->sciname );
 				flush();
 				ob_flush();
 			}

--- a/classes/TaxonomyHarvester.php
+++ b/classes/TaxonomyHarvester.php
@@ -153,7 +153,7 @@ class TaxonomyHarvester extends Manager{
 				if($resultArr['total']){
 					//Evaluate and rank each result to determine which is the best suited target
 					$inputTestArr = array($sciName);
-					if(mb_strpos($sciName, '×') !== false) $inputTestArr[] = trim(str_replace(array('× ','×'), '', $sciName));
+					//if(mb_strpos($sciName, '×') !== false) $inputTestArr[] = trim(str_replace(array('× ','×'), '', $sciName));
 					if(mb_strpos($sciName, '†') !== false) $inputTestArr[] = trim(str_replace(array('† ','†'), '', $sciName));
 					if(isset($taxonArr['rankid']) && $taxonArr['rankid'] > 220) $inputTestArr[] = trim($taxonArr['unitname1'].' '.$taxonArr['unitname2'].' '.$taxonArr['unitname3']);
 					$targetKey = 0;
@@ -164,9 +164,9 @@ class TaxonomyHarvester extends Manager{
 						$rankingArr[$k] = 0;
 						$isNotSimilar = true;
 						if(in_array($cbNameUsage['name']['scientificName'], $inputTestArr)) $isNotSimilar = false;
-						if(mb_strpos($cbNameUsage['name']['scientificName'], '×') !== false){
-							if(in_array(trim(str_replace(array('× ','×'), '', $cbNameUsage['name']['scientificName'])), $inputTestArr)) $isNotSimilar = false;
-						}
+						//if(mb_strpos($cbNameUsage['name']['scientificName'], '×') !== false){
+						//	if(in_array(trim(str_replace(array('× ','×'), '', $cbNameUsage['name']['scientificName'])), $inputTestArr)) $isNotSimilar = false;
+						//}
 						if (strpos($cbNameUsage['name']['scientificName'], '(') !== false) {
 							$cleanedName = preg_replace('/ \([^)]+\)/', '', $cbNameUsage['name']['scientificName']);
 							if (in_array(trim($cleanedName), $inputTestArr)) $isNotSimilar = false;


### PR DESCRIPTION
I only want to add to the taxonomy if cross names are exact - I don't want to match fuzzily.

Ex. '× Agroelymus palmerensis' != 'Agroelymus palmerensis'