### PR TITLE
Update batch harvester options to be more inclusive

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -40,7 +40,7 @@ class OccurrenceHarvester{
 		$retArr = array();
 		$sql = 'SELECT s.errorMessage AS errMsg, COUNT(s.samplePK) as sampleCnt, COUNT(o.occid) as occurrenceCnt '.
 			'FROM NeonSample s LEFT JOIN omoccurrences o ON s.occid = o.occid '.
-			'WHERE s.checkinuid IS NOT NULL AND s.sampleReceived = 1 AND o.collid IS NULL';
+			'WHERE s.checkinuid IS NOT NULL AND s.acceptedForAnalysis = 1';
 		if($shipmentPK) $sql .= 'AND s.shipmentPK = '.$shipmentPK;
 		$sql .= ' GROUP BY errMsg';
 		$rs= $this->conn->query($sql);

--- a/neon/occurrenceharvester.php
+++ b/neon/occurrenceharvester.php
@@ -160,7 +160,7 @@ include($SERVER_ROOT.'/includes/header.php');
 					</div>
 				</div>
 				<fieldset id="extendedVariables" style="display:<?php echo ($targetNewSample?'none':'block'); ?>">
-					<legend>Reharvesting Parameters</legend>
+					<legend>Harvesting Parameters</legend>
 					<div class="fieldGroupDiv">
 						<div class="fieldDiv">
 							Harvest date prior to: <input name="harvestDate" type="date" value="<?php echo $harvestDate; ?>" />


### PR DESCRIPTION
Batch "reharvesting" was actually only providing error options relevant to samples that had previously been harvested. It was also targeting samples not accepted for analysis #479 

