### PR TITLE
corrects issue with batch occurrence harvesting errors

### DIFF
--- a/neon/classes/OccHarvesterReports.php
+++ b/neon/classes/OccHarvesterReports.php
@@ -37,7 +37,7 @@
   public function getHarvestReport(){
     $dataArr = array();
 
-    $sql = 'SELECT sampleClass, errorMessage, COUNT(samplepk) AS cnt, GROUP_CONCAT(DISTINCT s.shipmentPK SEPARATOR ";") AS shipmentPK, GROUP_CONCAT(DISTINCT sh.shipmentID SEPARATOR ";") AS shipmentID FROM NeonSample s LEFT JOIN omoccurrences o ON o.occid = s.occid AND o.collid != "81" JOIN NeonShipment sh  ON s.shipmentPK = sh.shipmentPK WHERE errorMessage IS NOT NULL AND acceptedforanalysis = 1 AND s.checkinTimestamp IS NOT NULL GROUP BY sampleClass, errorMessage;';
+    $sql = 'SELECT sampleClass, errorMessage, COUNT(samplepk) AS cnt, GROUP_CONCAT(DISTINCT s.shipmentPK SEPARATOR ";") AS shipmentPK, GROUP_CONCAT(DISTINCT sh.shipmentID SEPARATOR ";") AS shipmentID FROM NeonSample s LEFT JOIN omoccurrences o ON o.occid = s.occid AND o.collid NOT IN (81,84,93) JOIN NeonShipment sh  ON s.shipmentPK = sh.shipmentPK WHERE errorMessage IS NOT NULL AND acceptedforanalysis = 1 AND s.checkinTimestamp IS NOT NULL GROUP BY sampleClass, errorMessage;';
 
     $result = $this->conn->query($sql);
 
@@ -66,7 +66,7 @@
   public function getTotalSamples(){
       $totalSamples = '';
 
-      $sql = 'SELECT count(s.samplePK) AS totalSamples FROM NeonSample s LEFT JOIN omoccurrences o ON s.occid = o.occid AND o.collid != "81"
+      $sql = 'SELECT count(s.samplePK) AS totalSamples FROM NeonSample s LEFT JOIN omoccurrences o ON s.occid = o.occid AND o.collid NOT IN (81,84,93)
 WHERE errorMessage IS NOT NULL AND s.checkinTimestamp IS NOT NULL AND acceptedforanalysis = 1;';
 
     $result = $this->conn->query($sql);


### PR DESCRIPTION
Updates batch occurrence harvester to allow for selection of errors associated only with "old" samples. Removes styling on error messages that was interfering with matching in sql queries targeting to samples by error. Also, excludes additional OPAL collections from error report. This should solve #479  and #481 

