### PR TITLE
Allow for harvesting of macroinvertebrate determinations

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -477,10 +477,10 @@ class OccurrenceHarvester{
 				if(strpos($tableName,'metagenomeSequencing')) continue;
 				if(strpos($tableName,'metabarcodeTaxonomy')) continue;
 				if(strpos($tableName,'pcrAmplification')) continue;
-				if(strpos($tableName,'perarchivesample')) continue;
-				if(strpos($tableName,'persample')) continue;
-				if(strpos($tableName,'pertaxon')) continue;
-				if(strpos($tableName,'pervial')) continue;
+				//if(strpos($tableName,'perarchivesample')) continue;
+				//if(strpos($tableName,'persample')) continue;
+				//if(strpos($tableName,'pertaxon')) continue;
+				//if(strpos($tableName,'pervial')) continue;
 				if($tableName == 'mpr_perpitprofile_in') continue;
 				$fieldArr = $eArr['smsFieldEntries'];
 				$fateLocation = ''; $fateDate = '';


### PR DESCRIPTION
This fix is needed in order to harvest any determinations for the macroinvertebrates. (Note, should be prepared that this may change harvesting behavior in other collections)
