### PR TITLE
Update query to remove null error message requirement

### DIFF
--- a/classes/OccurrenceSesar.php
+++ b/classes/OccurrenceSesar.php
@@ -780,7 +780,7 @@ class OccurrenceSesar extends Manager {
 		$sqlBase = 'FROM omoccurrences o WHERE (o.occurrenceid IS NULL) ';
 		if($this->namespace && $this->namespace == 'NEON'){
 			$sqlBase = 'FROM omoccurrences o INNER JOIN NeonSample s ON o.occid = s.occid
-				WHERE (o.occurrenceid IS NULL) AND (s.errorMessage IS NULL) AND (s.sampleReceived = 1) AND (s.acceptedForAnalysis = 1)
+				WHERE (o.occurrenceid IS NULL) AND (s.sampleReceived = 1) AND (s.acceptedForAnalysis = 1)
 				AND (s.checkinUid IS NOT NULL) AND (s.occid = s.occidOriginal) ';
 		}
 		if($this->collid) $sqlBase .= 'AND (o.collid = '.$this->collid.') ';

--- a/neon/classes/IgsnManager.php
+++ b/neon/classes/IgsnManager.php
@@ -21,7 +21,7 @@ class IgsnManager{
 		$sql = 'SELECT c.collid, CONCAT_WS("-",c.institutioncode,c.collectioncode) as collcode, c.collectionname, count(o.occid) as cnt
 			FROM omoccurrences o INNER JOIN omcollections c ON o.collid = c.collid
 			INNER JOIN NeonSample s ON o.occid = s.occid
-			WHERE c.institutionCode = "NEON" AND c.collid NOT IN(81,84,93) AND o.occurrenceId IS NULL AND s.errorMessage IS NULL AND s.sampleReceived = 1
+			WHERE c.institutionCode = "NEON" AND c.collid NOT IN(81,84,93) AND o.occurrenceId IS NULL AND s.sampleReceived = 1
 			GROUP BY c.collid';
 		$rs = $this->conn->query($sql);
 		while($r = $rs->fetch_object()){


### PR DESCRIPTION
Remove requirement that the sample have no harvesting errors in order to be able to assign an IGSN. Having an occurrence record is sufficient and meeting the other criteria is sufficient, and this additional requirement is preventing us from assigning necessary IGSNs and creating labels in some cases.