### PR TITLE
Hotfix 2024 07 25 (#1591)

### DIFF
--- a/checklists/index.php
+++ b/checklists/index.php
@@ -43,11 +43,17 @@ $clManager->setProj($pid);
 						<?php
 						$projName = $projArr['name'];
 						if($projName == 'Miscellaneous Inventories') $projName = (isset($LANG['MISC_INVENTORIES'])?$LANG['MISC_INVENTORIES']:'Miscellaneous Inventories');
+						if($pid) echo '<a href="../projects/index.php?pid=' . $pid . '">';
 						echo $projName;
+						if($pid) echo '</a>';
+						if(!empty($projArr['displayMap'])){
+							?>
+							<a href="<?php echo "clgmap.php?pid=" . $pid; ?>" title='<?php echo (isset($LANG['SHOW_MAP'])?$LANG['SHOW_MAP']:'Show inventories on map'); ?>'>
+								<img src='../images/world.png' style='width:10px;border:0' />
+							</a>
+							<?php
+						}
 						?>
-						<a href="<?php echo "clgmap.php?pid=" . $pid; ?>" title='<?php echo (isset($LANG['SHOW_MAP'])?$LANG['SHOW_MAP']:'Show inventories on map'); ?>'>
-							<img src='../images/world.png' style='width:10px;border:0' />
-						</a>
 					</h3>
 					<ul>
 						<?php

--- a/classes/DwcArchiverPublisher.php
+++ b/classes/DwcArchiverPublisher.php
@@ -316,22 +316,27 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 	}
 
 	public function humanFileSize($filePath) {
+		$x = false;
 		if(substr($filePath,0,4)=='http') {
-			$x = array_change_key_case(get_headers($filePath, 1),CASE_LOWER);
-			if( strcasecmp($x[0], 'HTTP/1.1 200 OK') != 0 ) {
-				$x = $x['content-length'][1];
-			}
-			else {
-				$x = $x['content-length'];
+			if($headerArr = @get_headers($filePath, 1)){
+				$x = array_change_key_case($headerArr, CASE_LOWER);
+				if( strcasecmp($x[0], 'HTTP/1.1 200 OK') != 0 ) {
+					$x = $x['content-length'][1];
+				}
+				else {
+					$x = $x['content-length'];
+				}
 			}
 		}
 		else {
 			$x = @filesize($filePath);
 		}
-		$x = round($x/1000000, 1);
-		if(!$x) $x = 0.1;
-
-		return $x.'M ';
+		if($x !== false){
+			$x = round($x/1000000, 1);
+			if(!$x) $x = 0.1;
+			return $x.'M';
+		}
+		return '?M';
 	}
 }
 ?>

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -2,7 +2,7 @@
 header('X-Frame-Options: DENY');
 header('Cache-control: private'); // IE 6 FIX
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.0.32';
+$CODE_VERSION = '3.0.33';
 
 if(!isset($CLIENT_ROOT) && isset($clientRoot)) $CLIENT_ROOT = $clientRoot;
 if(substr($CLIENT_ROOT,-1) == '/') $CLIENT_ROOT = substr($CLIENT_ROOT,0,strlen($CLIENT_ROOT)-1);

--- a/ident/index.php
+++ b/ident/index.php
@@ -43,7 +43,11 @@ $clManager->setPid($pid);
 			foreach($projArr as $pidKey => $pArr){
 				$clArr = $pArr['clid'];
 				echo '<div style="margin:3px 0px 0px 15px;">';
-				echo '<h3>'.$pArr['name'].' <a href="../checklists/clgmap.php?pid='.$pidKey.'&target=keys"><img src="../images/world.png" style="width:10px;border:0" /></a></h3>';
+				echo '<h3>' . $pArr['name'];
+				if(!empty($pArr['displayMap'])){
+					echo ' <a href="../checklists/clgmap.php?pid=' . $pidKey . '&target=keys"><img src="../images/world.png" style="width:10px;border:0" /></a>';
+				}
+				echo '</h3>';
 				echo '<div><ul>';
 				foreach($clArr as $clid => $clName){
 					echo '<li><a href="key.php?clid='.$clid.'&pid='.$pidKey.'&taxon=All+Species">'.$clName.'</a></li>';


### PR DESCRIPTION
- Inventory and Project Management  -- Display all checklists that have at least one linked taxon OR is a parent checklist inheriting taxa from a child checklist ([Issue #1532](https://github.com/BioKIC/Symbiota/issues/1532)) -- Removed limit that required checklist to have at least 10 linked taxa -- Order checklists by project and checklists names -- Only display Global symbol within map display option when one or more checklists within a group have lat/long centroids -- Make project title an active link that opens the project within the project details page
- DwC-A Publishing  -- Fix fatal error when DwC-A path fails to return a data file

