### PR TITLE
Adds ability to search manifests by "dynamicProperties" (e.g. containerID)

### DIFF
--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -942,6 +942,10 @@ class ShipmentManager{
 				$sqlWhere .= 'AND (s.trackingNumber = "'.$trackingId.'") ';
 				$this->searchArr['trackingNumber'] = $_REQUEST['trackingNumber'];
 			}
+			if(isset($_REQUEST['dynamicProperties']) && $_REQUEST['dynamicProperties']){
+				$sqlWhere .= 'AND (m.dynamicProperties LIKE "%'.$this->cleanInStr($_REQUEST['dynamicProperties']).'%") ';
+				$this->searchArr['dynamicProperties'] = $_REQUEST['dynamicProperties'];
+			}
 			if(isset($_REQUEST['dateShippedStart']) && $_REQUEST['dateShippedStart']){
 				$sqlWhere .= 'AND (s.dateShipped > "'.$_REQUEST['dateShippedStart'].'") ';
 				$this->searchArr['dateShippedStart'] = $_REQUEST['dateShippedStart'];

--- a/neon/shipment/manifestsearch.php
+++ b/neon/shipment/manifestsearch.php
@@ -49,6 +49,7 @@ if($isEditor){
 			f.sampleClass.value = "";
 			f.taxonID.value = "";
 			f.trackingNumber.value = "";
+			f.dynamicProperties.value = "";
 			f.dateShippedStart.value = "";
 			f.dateShippedEnd.value = "";
 			f.dateCheckinStart.value = "";
@@ -140,6 +141,11 @@ include($SERVER_ROOT.'/includes/header.php');
 				<div class="fieldGroupDiv">
 					<div class="fieldDiv">
 						<b>Tracking Number:</b> <input name="trackingNumber" type="text" value="<?php echo (isset($searchArgumentArr['trackingNumber'])?$searchArgumentArr['trackingNumber']:''); ?>" />
+					</div>
+				</div>
+				<div class="fieldGroupDiv">
+					<div class="fieldDiv">
+						<b>Dynamic Properties:</b> <input name="dynamicProperties" type="text" value="<?php echo (isset($searchArgumentArr['dynamicProperties'])?$searchArgumentArr['dynamicProperties']:''); ?>" />
 					</div>
 				</div>
 				<div class="fieldGroupDiv">


### PR DESCRIPTION
Isa requested the ability to search manifests by "containerID" which is part of the dynamicProperties field

May later want to update this in order to make it more specifically searchable by containerID if it gets confusing, but this way might be helpful if other aspects of dynamicProperties are of interest, too.

