### PR TITLE
Sample checkin sessioning

### DIFF
--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -495,6 +495,7 @@ class ShipmentManager{
 					if(isset($_SESSION['sampleCheckinSessionData']) && !isset($_SESSION['sampleCheckinSessionData']['end_time'])) {
 						$sessionData = json_encode($_SESSION['sampleCheckinSessionData']);
 						$sqlUpdate .= ', sessionData = \'' . $this->cleanInStr($sessionData) . '\' ';
+						$sqlUpdate .= ', sessionID = \'' . $this->cleanInStr(substr($_SESSION['sampleCheckinSessionData']['sessionID'], strrpos($_SESSION['sampleCheckinSessionData']['sessionID'], '-') + 1)) . '\' ';
 					}
 					$sqlUpdate .= 'WHERE (samplePK = "'.$samplePK.'") ';
 					if(!$this->conn->query($sqlUpdate)){
@@ -522,6 +523,7 @@ class ShipmentManager{
 				if(isset($_SESSION['sampleCheckinSessionData']) && !isset($_SESSION['sampleCheckinSessionData']['end_time'])) {
 					$sessionData = json_encode($_SESSION['sampleCheckinSessionData']);
 					$sql .= ', sessionData = \'' . $this->cleanInStr($sessionData) . '\' ';
+					$sql .= ', sessionID = \'' . $this->cleanInStr(substr($_SESSION['sampleCheckinSessionData']['sessionID'], strrpos($_SESSION['sampleCheckinSessionData']['sessionID'], '-') + 1)) . '\' ';
 				}
 				$sql .= 'WHERE (shipmentpk = '.$this->shipmentPK.') AND (checkinTimestamp IS NULL) AND (samplePK IN('.implode(',', $pkArr).'))';
 				if(!$this->conn->query($sql)){
@@ -1076,7 +1078,7 @@ class ShipmentManager{
 		$fileName .= date('Y-m-d').'.csv';
 		$sql = 'SELECT s.shipmentID, m.samplePK, m.sampleID, m.alternativeSampleID, m.sampleCode, m.sampleClass, m.taxonID, m.individualCount, m.filterVolume, m.namedlocation, '.
 			'm.domainremarks, m.collectdate, m.quarantineStatus, m.sampleReceived, m.acceptedForAnalysis, m.sampleCondition, m.dynamicProperties, m.symbiotaTarget, m.errorMessage, m.notes, m.occid, '.
-			'CONCAT_WS(", ",u.lastname, u.firstname) AS checkinUser, m.checkinTimestamp, m.initialtimestamp '.
+			'CONCAT_WS(", ",u.lastname, u.firstname) AS checkinUser, m.sessionData, m.checkinTimestamp, m.initialtimestamp '.
 			'FROM NeonShipment s INNER JOIN NeonSample m ON s.shipmentpk = m.shipmentpk '.
 			'LEFT JOIN users u ON m.checkinUid = u.uid ';
 		$sql .= $this->getFilteredWhereSql();
@@ -1186,9 +1188,9 @@ class ShipmentManager{
 		
 		$returnArray = [];
 		foreach ($retArr as $key => $session) {
-			$startTime = $session['start_time'];
-			$endTime = $session['end_time'] ?? 'N/A';
-			$returnArray[$key] = $startTime . ' to ' . $endTime;
+			if(isset($session['sessionID'])){
+				$returnArray[$key] = $session['sessionID'];
+			}
 		}
 
 		return $returnArray;

--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -976,6 +976,10 @@ class ShipmentManager{
 				$this->searchArr['senderID'] = $_REQUEST['senderID'];
 			 }
 			 */
+			if(isset($_REQUEST['sessionData']) && $_REQUEST['sessionData']){
+				$sqlWhere .= 'AND ((m.sessionData = "'.$this->conn->real_escape_string($_REQUEST['sessionData']).'")) ';
+				$this->searchArr['sessionData'] = $_REQUEST['sessionData'];
+			}
 			if(isset($_REQUEST['checkinUid']) && $_REQUEST['checkinUid']){
 				$sqlWhere .= 'AND ((s.checkinUid = "'.$_REQUEST['checkinUid'].'") OR (m.checkinUid = "'.$_REQUEST['checkinUid'].'")) ';
 				$this->searchArr['checkinUid'] = $_REQUEST['checkinUid'];
@@ -1164,6 +1168,32 @@ class ShipmentManager{
 		return $retArr;
 	}
 
+	public function getSessionDataArr(){
+		$retArr = array();
+		$sql = 'SELECT DISTINCT sessionData FROM NeonSample s WHERE sessionData IS NOT NULL';
+		$rs = $this->conn->query($sql);
+		while($r = $rs->fetch_object()){
+			$retArr[$r->sessionData] = json_decode($r->sessionData, true);
+		}
+		
+		uasort($retArr, function($a, $b) {
+			$startComparison = strcmp($a['start_time'], $b['start_time']);
+			if ($startComparison === 0) {
+				return strcmp($a['end_time'], $b['end_time']);
+			}
+			return $startComparison;
+		});
+		
+		$returnArray = [];
+		foreach ($retArr as $key => $session) {
+			$startTime = $session['start_time'];
+			$endTime = $session['end_time'] ?? 'N/A';
+			$returnArray[$key] = $startTime . ' to ' . $endTime;
+		}
+
+		return $returnArray;
+	}	
+	
 	public function getTrackingStr(){
 		$retStr = '';
 		if($this->shipmentArr['trackingNumber']){

--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -492,6 +492,10 @@ class ShipmentManager{
 					if($condition) $sqlUpdate .= ', sampleCondition = CONCAT_WS("; ",sampleCondition,"'.$this->cleanInStr($condition).'") ';
 					if($notes) $sqlUpdate .= ', checkinRemarks = "'.$this->cleanInStr($notes).'" ';
 					if($alternativeSampleID) $sqlUpdate .= ', alternativeSampleID = "'.$this->cleanInStr($alternativeSampleID).'" ';
+					if(isset($_SESSION['sampleCheckinSessionData']) && !isset($_SESSION['sampleCheckinSessionData']['end_time'])) {
+						$sessionData = json_encode($_SESSION['sampleCheckinSessionData']);
+						$sqlUpdate .= ', sessionData = \'' . $this->cleanInStr($sessionData) . '\' ';
+					}
 					$sqlUpdate .= 'WHERE (samplePK = "'.$samplePK.'") ';
 					if(!$this->conn->query($sqlUpdate)){
 						$this->errorStr = 'ERROR checking-in NEON sample: '.$this->conn->error;
@@ -513,9 +517,13 @@ class ShipmentManager{
 				if(isset($postArr['acceptedForAnalysis'])) $acceptedForAnalysis = ($postArr['acceptedForAnalysis']?1:0);
 				$sql = 'UPDATE NeonSample SET '.
 					'checkinUid = '.$GLOBALS['SYMB_UID'].', checkinTimestamp = now(), sampleReceived = '.$sampleReceived.', acceptedForAnalysis = '.$acceptedForAnalysis.' '.
-					($postArr['sampleCondition']?', sampleCondition = "'.$this->cleanInStr($postArr['sampleCondition']).'" ':'').
-					($postArr['checkinRemarks']?', checkinRemarks = "'.$this->cleanInStr($postArr['checkinRemarks']).'" ':'').
-					'WHERE (shipmentpk = '.$this->shipmentPK.') AND (checkinTimestamp IS NULL) AND (samplePK IN('.implode(',', $pkArr).'))';
+					($postArr['sampleCondition'] ? ', sampleCondition = "'.$this->cleanInStr($postArr['sampleCondition']).'" ' : '').
+					($postArr['checkinRemarks'] ? ', checkinRemarks = "'.$this->cleanInStr($postArr['checkinRemarks']).'" ' : '');
+				if(isset($_SESSION['sampleCheckinSessionData']) && !isset($_SESSION['sampleCheckinSessionData']['end_time'])) {
+					$sessionData = json_encode($_SESSION['sampleCheckinSessionData']);
+					$sql .= ', sessionData = \'' . $this->cleanInStr($sessionData) . '\' ';
+				}
+				$sql .= 'WHERE (shipmentpk = '.$this->shipmentPK.') AND (checkinTimestamp IS NULL) AND (samplePK IN('.implode(',', $pkArr).'))';
 				if(!$this->conn->query($sql)){
 					$this->errorStr = 'ERROR batch checking-in samples: '.$this->conn->error;
 					return false;

--- a/neon/shipment/manifestsearch.php
+++ b/neon/shipment/manifestsearch.php
@@ -55,6 +55,7 @@ if($isEditor){
 			f.dateCheckinStart.value = "";
 			f.dateCheckinEnd.value = "";
 			f.checkinUid.value = "";
+			f.sessionData.value = "";
 			f.importedUid.value = "";
 			f.sampleCondition.value = "";
 			var radioList = document.getElementsByName('manifestStatus');
@@ -158,6 +159,19 @@ include($SERVER_ROOT.'/includes/header.php');
 					<div class="fieldDiv">
 						<b>Sample Check-in Date:</b> <input name="dateCheckinStart" type="date" value="<?php echo (isset($searchArgumentArr['dateCheckinStart'])?$searchArgumentArr['dateCheckinStart']:''); ?>" /> -
 						<input name="dateCheckinEnd" type="date" value="<?php echo (isset($searchArgumentArr['dateCheckinEnd'])?$searchArgumentArr['dateCheckinEnd']:''); ?>" />
+					</div>
+					<div class="fieldDiv">
+						<b>Session: </b>
+						<select name="sessionData" style="margin:5px 10px">
+							<option value="">All Records</option>
+							<option value="">------------------------</option>
+							<?php
+							$sessionDataArr = $shipManager->getSessionDataArr();
+							foreach($sessionDataArr as $key => $sessionData){
+								echo '<option value="'.htmlspecialchars($key).'" '.(isset($searchArgumentArr['sessionData'])&&$key==$searchArgumentArr['sessionData']?'SELECTED':'').'>'.$sessionData.'</option>';
+							}
+							?>
+						</select>
 					</div>
 				</div>
 				<div class="fieldGroupDiv">

--- a/neon/shipment/manifestviewer.php
+++ b/neon/shipment/manifestviewer.php
@@ -365,8 +365,14 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			<?php else: ?>
 				toggleButtons(false); // Enable Start and Disable Stop
 			<?php endif; ?>
-			document.getElementById('start_session').addEventListener('click', startSession);
-			document.getElementById('stop_session').addEventListener('click', stopSession);
+			document.querySelectorAll('.start_session').forEach(button => {
+				button.addEventListener('click', startSession);
+			});
+		
+			// Attach event listeners to all stop session buttons
+			document.querySelectorAll('.stop_session').forEach(button => {
+				button.addEventListener('click', stopSession);
+			});
 		});
 	
 		function startSession() {
@@ -426,19 +432,33 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				minutes = String(minutes).padStart(2, '0');
 				seconds = String(seconds).padStart(2, '0');
 				
-				document.getElementById('timer').textContent = hours + ":" + minutes + ":" + seconds;
+				let timers = document.querySelectorAll('.timer');
+				timers.forEach(timer => {
+					timer.textContent = hours + ":" + minutes + ":" + seconds;
+				});
 			}, 1000);
 		}
 	
 		function stopTimer() {
 			// Clear the timer interval and reset the timer display
 			clearInterval(timerInterval);
-			document.getElementById('timer').textContent = "00:00:00";
+			let timers = document.querySelectorAll('.timer');
+			timers.forEach(timer => {
+				timer.textContent = "00:00:00";
+			});
 		}
 		
 		function toggleButtons(isSessionActive) {
-			document.getElementById('start_session').disabled = isSessionActive;
-			document.getElementById('stop_session').disabled = !isSessionActive;
+			let startButtons = document.querySelectorAll('.start_session');
+			let stopButtons = document.querySelectorAll('.stop_session');
+		
+			startButtons.forEach(button => {
+				button.disabled = isSessionActive;
+			});
+		
+			stopButtons.forEach(button => {
+				button.disabled = !isSessionActive;
+			});
 		}
 	</script>
 	<style type="text/css">
@@ -564,9 +584,9 @@ include($SERVER_ROOT.'/includes/header.php');
 							<div id="sampleCheckinDiv" style="margin-top:15px;background-color:white;top:50px;right:200px">
 								<fieldset style="padding:10px;width:500px">
 									<legend>Sample Check-in</legend>
-									<input type="radio" id="start_session" name="session" value="start"> Start Session
-									<input type="radio" id="stop_session" name="session" value="stop"> Stop Session
-									<div id="timer">00:00:00</div>
+									<input type="radio" class="start_session" name="session" value="start"> Start Session
+									<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
+									<div class="timer">00:00:00</div>
 									<form name="submitform" method="post" onsubmit="checkinSample(this); return false;">
 										<div id="popoutDiv" style="float:right"><a href="#" onclick="popoutCheckinBox();return false" title="Popout Sample Check-in Box">&gt;&gt;</a></div>
 										<div id="bindDiv" style="float:right;display:none"><a href="#" onclick="bindCheckinBox();return false" title="Bind Sample Check-in Box to top of form">&lt;&lt;</a></div>
@@ -806,6 +826,11 @@ include($SERVER_ROOT.'/includes/header.php');
 												<?php
 												if($shipArr['checkinTimestamp']){
 													?>
+													<div class="displayFieldDiv">
+														<input type="radio" class="start_session" name="session" value="start"> Start Session
+														<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
+														<div class="timer">00:00:00</div>
+													</div>	
 													<div class="displayFieldDiv">
 														<b>Sample Received:</b>
 														<input name="sampleReceived" type="radio" value="1" checked /> Yes

--- a/neon/shipment/manifestviewer.php
+++ b/neon/shipment/manifestviewer.php
@@ -38,8 +38,8 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 	$activeSession = false;
 	$sessionStartTime = null;
 	
-	if (isset($_SESSION['session_data'])) {
-		$session_data = json_decode($_SESSION['session_data'], true);
+	if (isset($_SESSION['sampleCheckinSessionData'])) {
+		$session_data = $_SESSION['sampleCheckinSessionData'];
 	
 		// Check if the session is active (end_time is null)
 		if ($session_data['end_time'] === null) {

--- a/neon/shipment/manifestviewer.php
+++ b/neon/shipment/manifestviewer.php
@@ -355,7 +355,6 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		}
 		
 		let timerInterval;
-		let currentUser = "<?php echo htmlspecialchars($USERNAME, ENT_QUOTES, 'UTF-8'); ?>"; // PHP Username
 	
 		// Check if a session is already active on page load
 		document.addEventListener('DOMContentLoaded', function() {
@@ -383,8 +382,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({
-					action: 'start_session',
-					user: currentUser
+					action: 'start_session'
 				})
 			}).then(response => response.json())
 			  .then(data => {

--- a/neon/shipment/manifestviewer.php
+++ b/neon/shipment/manifestviewer.php
@@ -37,6 +37,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 
 	$activeSession = false;
 	$sessionStartTime = null;
+	$sessionID = null;
 	
 	if (isset($_SESSION['sampleCheckinSessionData'])) {
 		$session_data = $_SESSION['sampleCheckinSessionData'];
@@ -45,6 +46,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		if ($session_data['end_time'] === null) {
 			$activeSession = true;
 			$sessionStartTime = $session_data['start_time'];
+			$sessionID = $session_data['sessionID'];
 		}
 	}
 	?>
@@ -355,14 +357,18 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		}
 		
 		let timerInterval;
+
+		let serverStartTime = "<?php echo $sessionStartTime; ?>";
+		let sessionID = "<?php echo $sessionID; ?>";
 	
 		// Check if a session is already active on page load
 		document.addEventListener('DOMContentLoaded', function() {
 			<?php if ($activeSession): ?>
-				startTimer(serverStartTime); // Automatically start the timer with the adjusted time
-				toggleButtons(true); // Disable Start and Enable Stop
+				startTimer(serverStartTime);
+				toggleButtons(true);
+				showSessionID(sessionID);
 			<?php else: ?>
-				toggleButtons(false); // Enable Start and Disable Stop
+				toggleButtons(false);
 			<?php endif; ?>
 			document.querySelectorAll('.start_session').forEach(button => {
 				button.addEventListener('click', startSession);
@@ -389,6 +395,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				  console.log('Session started at:', data.start_time);
 				  startTimer(data.start_time);
 				  toggleButtons(true);
+				  showSessionID(data.sessionID);
 			  });
 		}
 	
@@ -407,9 +414,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				  toggleButtons(false);
 			  });
 		}
-		
-		let serverStartTime = "<?php echo $sessionStartTime; ?>";
-		
+				
 		function startTimer(startTime) {
 			let start = new Date(startTime);
 	
@@ -417,7 +422,6 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			if (timerInterval) {
 				clearInterval(timerInterval);
 			}
-	
 			// Start the interval timer
 			timerInterval = setInterval(function() {
 				let now = new Date(new Date().toLocaleString("en-US", {timeZone: "America/Phoenix"}))
@@ -457,6 +461,14 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			stopButtons.forEach(button => {
 				button.disabled = !isSessionActive;
 			});
+		}
+		
+		function showSessionID(sessionID) {
+			let sessionIDdivs = document.querySelectorAll('.sessionID');
+			
+			sessionIDdivs.forEach(div => {
+				div.innerHTML  = '<strong>SessionID:</strong> ' + sessionID;
+			});	
 		}
 	</script>
 	<style type="text/css">
@@ -585,6 +597,7 @@ include($SERVER_ROOT.'/includes/header.php');
 									<input type="radio" class="start_session" name="session" value="start"> Start Session
 									<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
 									<div class="timer">00:00:00</div>
+									<div class="sessionID"></div>
 									<form name="submitform" method="post" onsubmit="checkinSample(this); return false;">
 										<div id="popoutDiv" style="float:right"><a href="#" onclick="popoutCheckinBox();return false" title="Popout Sample Check-in Box">&gt;&gt;</a></div>
 										<div id="bindDiv" style="float:right;display:none"><a href="#" onclick="bindCheckinBox();return false" title="Bind Sample Check-in Box to top of form">&lt;&lt;</a></div>
@@ -828,6 +841,7 @@ include($SERVER_ROOT.'/includes/header.php');
 														<input type="radio" class="start_session" name="session" value="start"> Start Session
 														<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
 														<div class="timer">00:00:00</div>
+														<div class="sessionID"></div>
 													</div>	
 													<div class="displayFieldDiv">
 														<b>Sample Received:</b>

--- a/neon/shipment/rpc/sessionManager.php
+++ b/neon/shipment/rpc/sessionManager.php
@@ -1,0 +1,32 @@
+<?php
+include_once('../../../config/symbini.php');
+// Check if session is not already active
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$request_body = file_get_contents('php://input');
+$data = json_decode($request_body, true);
+
+if ($data['action'] === 'start_session') {
+    $session_data = [
+        'user' => $data['user'],
+        'start_time' => date('Y-m-d H:i:s'),
+        'end_time' => null
+    ];
+
+    $_SESSION['session_data'] = json_encode($session_data);
+
+    // Return session data to frontend
+    echo json_encode(['start_time' => $session_data['start_time']]);
+}
+
+if ($data['action'] === 'stop_session') {
+    $session_data = json_decode($_SESSION['session_data'], true);
+    $session_data['end_time'] = date('Y-m-d H:i:s');
+    $_SESSION['session_data'] = json_encode($session_data);
+
+    // Return session end time to frontend
+    echo json_encode(['end_time' => $session_data['end_time']]);
+}
+?>

--- a/neon/shipment/rpc/sessionManager.php
+++ b/neon/shipment/rpc/sessionManager.php
@@ -1,5 +1,8 @@
 <?php
 include_once('../../../config/symbini.php');
+include_once($SERVER_ROOT.'/config/dbconnection.php');
+
+
 // Check if session is not already active
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
@@ -14,16 +17,26 @@ if ($data['action'] === 'start_session') {
         'end_time' => null
     ];
 
-    $_SESSION['session_data'] = json_encode($session_data);
+    $_SESSION['sampleCheckinSessionData'] = $session_data;
 
     // Return session data to frontend
     echo json_encode(['start_time' => $session_data['start_time']]);
 }
 
 if ($data['action'] === 'stop_session') {
-    $session_data = json_decode($_SESSION['session_data'], true);
+    $conn = MySQLiConnectionFactory::getCon("write");
+    $session_data = $_SESSION['sampleCheckinSessionData'];
     $session_data['end_time'] = date('Y-m-d H:i:s');
-    $_SESSION['session_data'] = json_encode($session_data);
+    $end_session_data_json = json_encode($session_data);
+    $start_session_data_json = json_encode($_SESSION['sampleCheckinSessionData']);    
+    
+    $sqlUpdate = "UPDATE NeonSample 
+                  SET sessionData = '" . $conn->real_escape_string($end_session_data_json) . "' 
+                  WHERE sessionData = '" . $conn->real_escape_string($start_session_data_json) . "'";
+    
+    $conn->query($sqlUpdate);
+    if($conn) $conn->close();
+    $_SESSION['sampleCheckinSessionData'] = $session_data;
 
     // Return session end time to frontend
     echo json_encode(['end_time' => $session_data['end_time']]);

--- a/neon/shipment/rpc/sessionManager.php
+++ b/neon/shipment/rpc/sessionManager.php
@@ -30,7 +30,7 @@ if ($data['action'] === 'start_session') {
     $_SESSION['sampleCheckinSessionData'] = $session_data;
 
     // Return session data to frontend
-    echo json_encode(['start_time' => $session_data['start_time']]);
+    echo json_encode(['start_time' => $session_data['start_time'], 'sessionID' => $session_data['sessionID']]);
 }
 
 if ($data['action'] === 'stop_session') {

--- a/neon/shipment/rpc/sessionManager.php
+++ b/neon/shipment/rpc/sessionManager.php
@@ -12,9 +12,19 @@ $request_body = file_get_contents('php://input');
 $data = json_decode($request_body, true);
 
 if ($data['action'] === 'start_session') {
+    $conn = MySQLiConnectionFactory::getCon("write");
+    $sql = "SELECT LPAD(MAX(sessionID)+1, 3, '0') AS sessionNumber FROM NeonSample";    
+    $rs = $conn->query($sql);
+    while($r = $rs->fetch_object()){
+        $sessionNum = $r->sessionNumber;
+    }
+    $rs->free();    
+    if($conn) $conn->close();
+    
     $session_data = [
+        'sessionID' => $USERNAME.'-'.$sessionNum,
         'start_time' => date('Y-m-d H:i:s'),
-        'end_time' => null
+        'end_time' => null,
     ];
 
     $_SESSION['sampleCheckinSessionData'] = $session_data;

--- a/neon/shipment/rpc/sessionManager.php
+++ b/neon/shipment/rpc/sessionManager.php
@@ -10,7 +10,6 @@ $data = json_decode($request_body, true);
 
 if ($data['action'] === 'start_session') {
     $session_data = [
-        'user' => $data['user'],
         'start_time' => date('Y-m-d H:i:s'),
         'end_time' => null
     ];

--- a/neon/shipment/samplecheckin.php
+++ b/neon/shipment/samplecheckin.php
@@ -19,6 +19,19 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		<?php
 		$activateJQuery = true;
 		include_once($SERVER_ROOT.'/includes/head.php');
+		
+		$activeSession = false;
+		$sessionStartTime = null;
+		
+		if (isset($_SESSION['session_data'])) {
+			$session_data = json_decode($_SESSION['session_data'], true);
+		
+			// Check if the session is active (end_time is null)
+			if ($session_data['end_time'] === null) {
+				$activeSession = true;
+				$sessionStartTime = $session_data['start_time'];
+			}
+		}
 		?>
 		<script src="../../js/jquery-3.2.1.min.js" type="text/javascript"></script>
 		<script src="../../js/jquery-ui-1.12.1/jquery-ui.min.js" type="text/javascript"></script>
@@ -120,6 +133,113 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				var listElem = document.getElementById("samplelistdiv");
 				listElem.insertBefore(newDiv,listElem.childNodes[0]);
 			}
+			
+			let timerInterval;
+			let currentUser = "<?php echo htmlspecialchars($USERNAME, ENT_QUOTES, 'UTF-8'); ?>"; // PHP Username
+		
+			// Check if a session is already active on page load
+			document.addEventListener('DOMContentLoaded', function() {
+				<?php if ($activeSession): ?>
+					startTimer(serverStartTime); // Automatically start the timer with the adjusted time
+					toggleButtons(true); // Disable Start and Enable Stop
+				<?php else: ?>
+					toggleButtons(false); // Enable Start and Disable Stop
+				<?php endif; ?>
+				document.querySelectorAll('.start_session').forEach(button => {
+					button.addEventListener('click', startSession);
+				});
+			
+				// Attach event listeners to all stop session buttons
+				document.querySelectorAll('.stop_session').forEach(button => {
+					button.addEventListener('click', stopSession);
+				});
+			});
+		
+			function startSession() {
+				// Send AJAX request to start session
+				fetch('rpc/sessionManager.php', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({
+						action: 'start_session',
+						user: currentUser
+					})
+				}).then(response => response.json())
+				  .then(data => {
+					  console.log('Session started at:', data.start_time);
+					  startTimer(data.start_time);
+					  toggleButtons(true);
+				  });
+			}
+		
+			function stopSession() {
+				// Send AJAX request to stop session
+				fetch('rpc/sessionManager.php', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({ action: 'stop_session' })
+				}).then(response => response.json())
+				  .then(data => {
+					  console.log('Session ended at:', data.end_time);
+					  stopTimer();
+					  toggleButtons(false);
+				  });
+			}
+			
+			let serverStartTime = "<?php echo $sessionStartTime; ?>";
+			
+			function startTimer(startTime) {
+				let start = new Date(startTime);
+		
+				// Clear any existing timer before starting a new one
+				if (timerInterval) {
+					clearInterval(timerInterval);
+				}
+		
+				// Start the interval timer
+				timerInterval = setInterval(function() {
+					let now = new Date(new Date().toLocaleString("en-US", {timeZone: "America/Phoenix"}))
+					let diff = Math.floor((now - start) / 1000);
+					let hours = Math.floor(diff / 3600);
+					let minutes = Math.floor((diff % 3600) / 60);
+					let seconds = diff % 60;
+					
+					hours = String(hours).padStart(2, '0');
+					minutes = String(minutes).padStart(2, '0');
+					seconds = String(seconds).padStart(2, '0');
+					
+					let timers = document.querySelectorAll('.timer');
+					timers.forEach(timer => {
+						timer.textContent = hours + ":" + minutes + ":" + seconds;
+					});
+				}, 1000);
+			}
+		
+			function stopTimer() {
+				// Clear the timer interval and reset the timer display
+				clearInterval(timerInterval);
+				let timers = document.querySelectorAll('.timer');
+				timers.forEach(timer => {
+					timer.textContent = "00:00:00";
+				});
+			}
+			
+			function toggleButtons(isSessionActive) {
+				let startButtons = document.querySelectorAll('.start_session');
+				let stopButtons = document.querySelectorAll('.stop_session');
+			
+				startButtons.forEach(button => {
+					button.disabled = isSessionActive;
+				});
+			
+				stopButtons.forEach(button => {
+					button.disabled = !isSessionActive;
+				});
+			}
 		</script>
 		<style type="text/css">
 			fieldset{ padding:15px;width:600px }
@@ -143,6 +263,9 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				<div id="sampleCheckinDiv" style="width:900">
 					<fieldset style="width:100%">
 						<legend><b>Sample Check-in</b></legend>
+						<input type="radio" class="start_session" name="session" value="start"> Start Session
+						<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
+						<div class="timer">00:00:00</div>
 						<form name="submitform" method="post" onsubmit="checkinSample(this); return false;">
 							<div class="displayFieldDiv">
 								<b>Identifier:</b> <input name="identifier" type="text" style="width:275px" required />

--- a/neon/shipment/samplecheckin.php
+++ b/neon/shipment/samplecheckin.php
@@ -22,6 +22,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		
 		$activeSession = false;
 		$sessionStartTime = null;
+		$sessionID = null;
 		
 		if (isset($_SESSION['sampleCheckinSessionData'])) {
 			$session_data = $_SESSION['sampleCheckinSessionData'];
@@ -29,6 +30,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			if ($session_data['end_time'] === null) {
 				$activeSession = true;
 				$sessionStartTime = $session_data['start_time'];
+				$sessionID = $session_data['sessionID'];
 			}
 		}
 		?>
@@ -135,13 +137,17 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			
 			let timerInterval;
 		
+			let serverStartTime = "<?php echo $sessionStartTime; ?>";
+			let sessionID = "<?php echo $sessionID; ?>";
+		
 			// Check if a session is already active on page load
 			document.addEventListener('DOMContentLoaded', function() {
 				<?php if ($activeSession): ?>
-					startTimer(serverStartTime); // Automatically start the timer with the adjusted time
-					toggleButtons(true); // Disable Start and Enable Stop
+					startTimer(serverStartTime);
+					toggleButtons(true);
+					showSessionID(sessionID);
 				<?php else: ?>
-					toggleButtons(false); // Enable Start and Disable Stop
+					toggleButtons(false);
 				<?php endif; ?>
 				document.querySelectorAll('.start_session').forEach(button => {
 					button.addEventListener('click', startSession);
@@ -168,6 +174,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 					  console.log('Session started at:', data.start_time);
 					  startTimer(data.start_time);
 					  toggleButtons(true);
+					  showSessionID(data.sessionID);
 				  });
 			}
 		
@@ -186,9 +193,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 					  toggleButtons(false);
 				  });
 			}
-			
-			let serverStartTime = "<?php echo $sessionStartTime; ?>";
-			
+					
 			function startTimer(startTime) {
 				let start = new Date(startTime);
 		
@@ -196,7 +201,6 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 				if (timerInterval) {
 					clearInterval(timerInterval);
 				}
-		
 				// Start the interval timer
 				timerInterval = setInterval(function() {
 					let now = new Date(new Date().toLocaleString("en-US", {timeZone: "America/Phoenix"}))
@@ -237,6 +241,14 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 					button.disabled = !isSessionActive;
 				});
 			}
+			
+			function showSessionID(sessionID) {
+				let sessionIDdivs = document.querySelectorAll('.sessionID');
+				
+				sessionIDdivs.forEach(div => {
+					div.innerHTML  = '<strong>SessionID:</strong> ' + sessionID;
+				});	
+			}
 		</script>
 		<style type="text/css">
 			fieldset{ padding:15px;width:600px }
@@ -263,6 +275,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 						<input type="radio" class="start_session" name="session" value="start"> Start Session
 						<input type="radio" class="stop_session" name="session" value="stop"> Stop Session
 						<div class="timer">00:00:00</div>
+						<div class="sessionID"></div>
 						<form name="submitform" method="post" onsubmit="checkinSample(this); return false;">
 							<div class="displayFieldDiv">
 								<b>Identifier:</b> <input name="identifier" type="text" style="width:275px" required />

--- a/neon/shipment/samplecheckin.php
+++ b/neon/shipment/samplecheckin.php
@@ -23,9 +23,8 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 		$activeSession = false;
 		$sessionStartTime = null;
 		
-		if (isset($_SESSION['session_data'])) {
-			$session_data = json_decode($_SESSION['session_data'], true);
-		
+		if (isset($_SESSION['sampleCheckinSessionData'])) {
+			$session_data = $_SESSION['sampleCheckinSessionData'];
 			// Check if the session is active (end_time is null)
 			if ($session_data['end_time'] === null) {
 				$activeSession = true;

--- a/neon/shipment/samplecheckin.php
+++ b/neon/shipment/samplecheckin.php
@@ -135,7 +135,6 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 			}
 			
 			let timerInterval;
-			let currentUser = "<?php echo htmlspecialchars($USERNAME, ENT_QUOTES, 'UTF-8'); ?>"; // PHP Username
 		
 			// Check if a session is already active on page load
 			document.addEventListener('DOMContentLoaded', function() {
@@ -163,8 +162,7 @@ elseif(array_key_exists('CollAdmin',$USER_RIGHTS) || array_key_exists('CollEdito
 						'Content-Type': 'application/json'
 					},
 					body: JSON.stringify({
-						action: 'start_session',
-						user: currentUser
+						action: 'start_session'
 					})
 				}).then(response => response.json())
 				  .then(data => {


### PR DESCRIPTION
Added sessioning for sample check-in. Discussed and tested with Azhar, but would be helpful for someone in another time zone to check the timer function. 

Session information is stored in PHP upon session start, in SQL upon sample check-in and finalized information stored in SQL upon session end. Also updates manifest search to add search by session.

Will have to add 'sessionData' VARCHAR(100) and 'sessionID' INT(3) to NeonSample. Initialize sessionID with 0 somewhere.