### PR TITLE
Removes unnecessary warning message

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -713,6 +713,7 @@ class OccurrenceHarvester{
 				$skipTaxonomy = array(5,6,10,13,16,21,23,31,41,42,58,60,61,62,67,68,69,76,92,98);
 				if(!in_array($dwcArr['collid'],$skipTaxonomy)){
 					$identArr = array();
+					$taxonCode = '';
 					if(isset($sampleArr['identifications']) && !in_array($dwcArr['collid'], array(46))){
 						$identArr = $sampleArr['identifications'];
 					}


### PR DESCRIPTION
Trying to prevent the unnecessary warning message about undefined $taxonCode when taxonCode is not needed.
 
Tested and worked as expected but only on one record so lmk if you see any obvious reason this would cause a problem.