### PR TITLE
Quicksearch / Manifest link updates

### DIFF
--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -428,7 +428,7 @@ $traitArr = $indManager->getTraitArr();
 								
 									if($IS_ADMIN){
 										if($catTag == 'NEON sampleCode (barcode)' || $catTag == 'NEON sampleID'){
-											echo '<span style="margin-left: 10px"><a href="../../neon/shipment/manifestviewer.php?quicksearch=' . array_pop($catValueArr) . '" target="_blank">Go to Manifest</a></span>';
+											echo '<span style="margin-left: 10px"><a href="../../neon/shipment/manifestviewer.php?quicksearch=' . $occid. '" target="_blank">Go to Manifest</a></span>';
 										}
 									}
 									echo '</div>';

--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -1328,18 +1328,67 @@ class ShipmentManager{
 		if(is_numeric($id)) $this->shipmentPK = $id;
 	}
 
-	public function setQuickSearchTerm($term){
+	public function setQuickSearchTerm($term) {
 		$cleanTerm = $this->cleanInStr($term);
-		$sql = 'SELECT s.shipmentPK '.
-			'FROM NeonShipment s LEFT JOIN NeonSample m ON s.shipmentPK = m.shipmentPK '.
-			'WHERE (s.shipmentid LIKE "'.$cleanTerm.'%" OR m.sampleid = "'.$cleanTerm.'" OR m.alternativeSampleID = "'.$cleanTerm.'" OR m.sampleCode = "'.$cleanTerm.'")';
+	
+		// Try match by occid
+		$sql = 'SELECT s.shipmentPK 
+				FROM NeonShipment s 
+				LEFT JOIN NeonSample m ON s.shipmentPK = m.shipmentPK 
+				WHERE m.occid = "' . $cleanTerm . '"';
 		$rs = $this->conn->query($sql);
-		if($r = $rs->fetch_object()){
+		
+		if ($r = $rs->fetch_object()) {
+			$this->shipmentPK = $r->shipmentPK;
+			$rs->free();
+			return $this->shipmentPK;
+		}
+		$rs->free();
+
+				// Try match by catalogNumber
+				$sql = 'SELECT s.shipmentPK 
+				FROM NeonShipment s 
+				LEFT JOIN NeonSample m ON s.shipmentPK = m.shipmentPK 
+				LEFT JOIN omoccurrences o ON m.occid = o.occid
+				WHERE o.catalogNumber = "' . $cleanTerm . '"';
+		$rs = $this->conn->query($sql);
+		
+		if ($r = $rs->fetch_object()) {
+			$this->shipmentPK = $r->shipmentPK;
+			$rs->free();
+			return $this->shipmentPK;
+		}
+		$rs->free();
+	
+		// Try match by sampleCode
+		$sql = 'SELECT s.shipmentPK 
+				FROM NeonShipment s 
+				LEFT JOIN NeonSample m ON s.shipmentPK = m.shipmentPK 
+				WHERE m.sampleCode = "' . $cleanTerm . '"';
+		$rs = $this->conn->query($sql);
+		
+		if ($r = $rs->fetch_object()) {
+			$this->shipmentPK = $r->shipmentPK;
+			$rs->free();
+			return $this->shipmentPK;
+		}
+		$rs->free();
+	
+		// Try match by sampleID
+		$sql = 'SELECT s.shipmentPK 
+				FROM NeonShipment s 
+				LEFT JOIN NeonSample m ON s.shipmentPK = m.shipmentPK 
+				WHERE m.sampleid = "' . $cleanTerm . '"';
+		$rs = $this->conn->query($sql);
+		
+		if ($r = $rs->fetch_object()) {
 			$this->shipmentPK = $r->shipmentPK;
 		}
 		$rs->free();
+	
 		return $this->shipmentPK;
 	}
+
 
 	public function setUploadFileName($name){
 		$this->uploadFileName = $name;

--- a/neon/shipment/manifestviewer.php
+++ b/neon/shipment/manifestviewer.php
@@ -10,7 +10,6 @@ if(!$SYMB_UID) header('Location: ../../profile/index.php?refurl=' . $CLIENT_ROOT
 $shipmentPK = array_key_exists('shipmentPK', $_REQUEST) ? filter_var($_REQUEST['shipmentPK'], FILTER_SANITIZE_NUMBER_INT) : '';
 $sampleFilter = isset($_REQUEST['sampleFilter']) ? $_REQUEST['sampleFilter'] : '';
 $quickSearchTerm = array_key_exists('quicksearch', $_REQUEST) ? $_REQUEST['quicksearch'] : '';
-$quickSearchTerm = array_key_exists('quicksearch', $_REQUEST) ? $_REQUEST['quicksearch'] : '';
 $sortableTable = isset($_REQUEST['sortabletable']) ? filter_var($_REQUEST['sortabletable'], FILTER_SANITIZE_NUMBER_INT) : false;
 $action = array_key_exists('action', $_REQUEST) ? $_REQUEST['action'] : '';
 
@@ -821,7 +820,11 @@ include($SERVER_ROOT.'/includes/header.php');
 													echo '<td style="text-align:center">';
 													if(array_key_exists('occid',$sampleArr) && $sampleArr['occid']){
 														echo '<span title="harvested '.(isset($sampleArr['harvestTimestamp'])?$sampleArr['harvestTimestamp']:'').'">';
-														echo '<a href="../../collections/individual/index.php?occid='.$sampleArr['occid'].'" target="_blank">'.$sampleArr['occid'].'</a>';
+														if ($quickSearchTerm === $sampleArr['occid']) {
+															echo '<a href="../../collections/individual/index.php?occid=' . $sampleArr['occid'] . '" target="_blank"><strong>' . $sampleArr['occid'] . '</strong></a>';
+														} else {
+															echo '<a href="../../collections/individual/index.php?occid=' . $sampleArr['occid'] . '" target="_blank">' . $sampleArr['occid'] . '</a>';
+														}
 														echo '</br>';
 														echo '</br>';
 														echo '<a href="../../collections/editor/occurrenceeditor.php?occid='.$sampleArr['occid'].'" target="_blank"><img src="../../images/edit.png" style="width:13px" /></a>';


### PR DESCRIPTION
(1) Enables quick search by occid, catalogNumber, IGSN 
(2) Prioritizes matches based on "best" identifiers 
(3) Links from occurrence record back to manifest via occid to prevent incorrect linkage when sampleIDs are duplicated, which solves #601 
(4) bolds the occid in manifest when that is the quick search term
