### PR TITLE
Resolve taxonomy upload issues

### DIFF
--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -49,7 +49,7 @@ class TaxonomyUpload{
 			$this->uploadFileName = $_FILES['uploadfile']['name'];
 			move_uploaded_file($_FILES['uploadfile']['tmp_name'], $this->uploadTargetPath.$this->uploadFileName);
 		}
-		if(file_exists($this->uploadTargetPath.$this->uploadFileName) && substr($this->uploadFileName,-4) == ".zip"){
+		if(file_exists($this->uploadTargetPath.$this->uploadFileName) && substr($this->uploadFileName ?? '',-4) == ".zip"){
 			$zip = new ZipArchive;
 			$zip->open($this->uploadTargetPath.$this->uploadFileName);
 			$zipFile = $this->uploadTargetPath.$this->uploadFileName;
@@ -73,6 +73,10 @@ class TaxonomyUpload{
 
 		if(($fh = fopen($this->uploadTargetPath.$this->uploadFileName,'r')) !== FALSE){
 			$headerArr = fgetcsv($fh);
+			if(substr($headerArr[0], 0, 3) == chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
+				//Remove UTF-8 BOM
+				$headerArr[0] = trim(substr($headerArr[0], 3), ' "');
+			}
 			$uploadTaxaFieldArr = $this->getUploadTaxaFieldArr();
 			if(!$this->taxonUnitArr) $this->setTaxonUnitArr();
 			$taxonUnitArr = $this->taxonUnitArr;
@@ -213,13 +217,16 @@ class TaxonomyUpload{
 								if($k == 'author') $sql2 .= ',"'.($inValue?$inValue:'').'"';
 								else $sql2 .= ','.($inValue?'"'.$inValue.'"':'NULL');
 							}
-							$sql = 'INSERT INTO uploadtaxa('.substr($sql1,1).') VALUES('.substr($sql2,1).')';
+							$sql = 'INSERT IGNORE INTO uploadtaxa('.substr($sql1,1).') VALUES('.substr($sql2,1).')';
 							//echo '<div>'.$sql.'</div>';
 							if($this->conn->query($sql)){
 								if($recordCnt%1000 == 0){
 									$this->outputMsg('Upload count: '.$recordCnt,1);
 									ob_flush();
 									flush();
+								}
+								if($warnings = $this->conn->get_warnings()){
+									$this->outputMsg('WARNING at line ' . $recordCnt . ': ' . $warnings->message, 2);
 								}
 							}
 							else{
@@ -245,7 +252,7 @@ class TaxonomyUpload{
 						$this->outputMsg('ERROR loading taxonunit: '.$this->conn->error);
 					}
 				}
-				$this->outputMsg($recordCnt.' taxon records pre-processed');
+				$this->outputMsg(($recordCnt - 1) . ' taxon records pre-processed');
 			}
 			else{
 				$this->outputMsg('ERROR: Scientific name is not mapped to &quot;scinameinput&quot;');
@@ -814,7 +821,6 @@ class TaxonomyUpload{
 
 		//Update occurrences with new tids
 		$occurMaintenance = new OccurrenceMaintenance($this->conn);
-		$occurMaintenance->setCollidStr($this->collid);
 		$occurMaintenance->generalOccurrenceCleaning();
 		$occurMaintenance->batchUpdateGeoreferenceIndex();
 	}
@@ -911,11 +917,11 @@ class TaxonomyUpload{
 		$retArr = $this->getUploadTaxaFieldArr();
 		unset($retArr['unitind1']);
 		unset($retArr['unitind2']);
-		$retArr['unitname1'] = 'genus';
+		$retArr['unitname1'] = 'unitname1 (e.g. genus)';
 		//unset($retArr['genus']);
-		$retArr['unitname2'] = 'specificepithet';
-		$retArr['unitind3'] = 'taxonrank';
-		$retArr['unitname3'] = 'infraspecificepithet';
+		$retArr['unitname2'] = 'unitname2 (specificEpithet)';
+		$retArr['unitind3'] = 'unitind3 (taxonrank)';
+		$retArr['unitname3'] = 'unitname3 (infraSpecificEpithet)';
 		if(!$this->taxonUnitArr) $this->setTaxonUnitArr();
 		foreach($this->taxonUnitArr as $rankid => $rankName){
 			if($rankName != 'genus' && $rankid < 220) $retArr[$rankName] = $rankName;
@@ -952,8 +958,12 @@ class TaxonomyUpload{
 		$sourceArr = array();
 		if(($fh = fopen($this->uploadTargetPath.$this->uploadFileName,'r')) !== FALSE){
 			$headerArr = fgetcsv($fh);
+			if(substr($headerArr[0], 0, 3) == chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
+				//Remove UTF-8 BOM
+				$headerArr[0] = trim(substr($headerArr[0], 3), ' "');
+			}
 			foreach($headerArr as $field){
-				$fieldStr = strtolower(TRIM($field));
+				$fieldStr = trim($field);
 				if($fieldStr){
 					$sourceArr[] = $fieldStr;
 				}


### PR DESCRIPTION
- Remove BOM from import file, if present. Otherwise, parsing of header row fails
- Add IGNORE to avoid insert failures due to warnings
- Catch and report warnings so that user can resolve issues, if they wish
- Fix final count
- Misc adjustments to avoid warnings introduced by PHP 8.2 software update

