### PR TITLE
Add Alternative Identifier Ext to DwC-A export

### DIFF
--- a/classes/DwcArchiverAttribute.php
+++ b/classes/DwcArchiverAttribute.php
@@ -61,7 +61,7 @@ class DwcArchiverAttribute extends DwcArchiverBaseManager{
 		if($this->fieldArr){
 			$sqlFrag = '';
 			foreach($this->fieldArr['fields'] as $colName){
-				if($colName && $colName != 'msDynamicField') $sqlFrag .= ', '.$colName;
+				if($colName) $sqlFrag .= ', '.$colName;
 			}
 			$this->sqlBase = 'SELECT '.trim($sqlFrag,', ').'
 				FROM tmtraits m INNER JOIN tmstates s ON m.traitid = s.traitid

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -5,10 +5,12 @@ include_once($SERVER_ROOT . '/classes/DwcArchiverDetermination.php');
 include_once($SERVER_ROOT . '/classes/DwcArchiverImage.php');
 include_once($SERVER_ROOT . '/classes/DwcArchiverAttribute.php');
 include_once($SERVER_ROOT . '/classes/DwcArchiverMaterialSample.php');
-include_once($SERVER_ROOT . '/classes/UuidFactory.php');
+include_once($SERVER_ROOT . '/classes/DwcArchiverIdentifier.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceTaxaManager.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceAccessStats.php');
 include_once($SERVER_ROOT . '/classes/PortalIndex.php');
+include_once($SERVER_ROOT . '/classes/utilities/UuidFactory.php');
+include_once($SERVER_ROOT . '/classes/utilities/GeneralUtil.php');
 
 class DwcArchiverCore extends Manager{
 
@@ -43,6 +45,7 @@ class DwcArchiverCore extends Manager{
 	private $includeImgs = 1;
 	protected $includeAttributes = 0;
 	protected $includeMaterialSample = 0;
+	protected $includeIdentifiers = 0;
 	private $hasPaleo = false;
 	private $redactLocalities = 1;
 	private $rareReaderArr = array();
@@ -51,6 +54,7 @@ class DwcArchiverCore extends Manager{
 
 	private $attributeHandler = null;
 	private $materialSampleHandler = null;
+	private $identierHandler = null;
 
 	private $geolocateVariables = array();
 
@@ -436,7 +440,7 @@ class DwcArchiverCore extends Manager{
 			}
 			if (isset($dwcArray['occurrenceID']) || (isset($dwcArray['catalogNumber']) && isset($dwcArray['collectionCode']))) {
 				$occurrenceid = $dwcArray['occurrenceID'];
-				if (UuidFactory::is_valid($occurrenceid)) {
+				if (UuidFactory::isValid($occurrenceid)) {
 					$occurrenceid = "urn:uuid:$occurrenceid";
 				} else {
 					$catalogNumber = $dwcArray['catalogNumber'];
@@ -461,7 +465,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							case "collectionID":
 								// RDF Guide Section 2.3.3 owl:sameAs for urn:lsid and resolvable IRI.
-								if (stripos("urn:uuid:", $value) === false && UuidFactory::is_valid($value)) {
+								if (stripos("urn:uuid:", $value) === false && UuidFactory::isValid($value)) {
 									$lsid = "urn:uuid:$value";
 								} elseif (stripos("urn:lsid:biocol.org", $value) === 0) {
 									$lsid = "http://biocol.org/$value";
@@ -512,7 +516,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							default:
 								if (isset($occurTermArr[$key])) {
-									//$ns = RdfUtility::namespaceAbbrev($occurTermArr[$key]);
+									//$ns = RdfUtil::namespaceAbbrev($occurTermArr[$key]);
 									//$returnvalue .= $separator . "   " . $ns . " \"$value\"";
 								}
 						}
@@ -560,7 +564,7 @@ class DwcArchiverCore extends Manager{
 			}
 			if (isset($dwcArray['occurrenceID']) || (isset($dwcArray['catalogNumber']) && isset($dwcArray['collectionCode']))) {
 				$occurrenceid = $dwcArray['occurrenceID'];
-				if (UuidFactory::is_valid($occurrenceid)) {
+				if (UuidFactory::isValid($occurrenceid)) {
 					$occurrenceid = "urn:uuid:$occurrenceid";
 				} else {
 					$catalogNumber = $dwcArray['catalogNumber'];
@@ -591,7 +595,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							case "collectionID":
 								// RDF Guide Section 2.3.3 owl:sameAs for urn:lsid and resolvable IRI.
-								if (stripos("urn:uuid:", $value) === false && UuidFactory::is_valid($value)) {
+								if (stripos("urn:uuid:", $value) === false && UuidFactory::isValid($value)) {
 									$lsid = "urn:uuid:$value";
 								} elseif (stripos("urn:lsid:biocol.org", $value) === 0) {
 									$lsid = "http://biocol.org/$value";
@@ -649,7 +653,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							default:
 								if (isset($occurTermArr[$key])) {
-									//$ns = RdfUtility::namespaceAbbrev($occurTermArr[$key]);
+									//$ns = RdfUtil::namespaceAbbrev($occurTermArr[$key]);
 									//$elem = $newDoc->createElement($ns);
 									//$elem->appendChild($newDoc->createTextNode($value));
 								}
@@ -870,6 +874,10 @@ class DwcArchiverCore extends Manager{
 				$zipArchive->addFile($this->targetPath . $this->ts . '-matSample' . $this->fileExt);
 				$zipArchive->renameName($this->targetPath . $this->ts . '-matSample' . $this->fileExt, 'materialSample' . $this->fileExt);
 			}
+			if ($this->includeIdentifiers && file_exists($this->targetPath . $this->ts . '-ident' . $this->fileExt)) {
+				$zipArchive->addFile($this->targetPath . $this->ts . '-ident' . $this->fileExt);
+				$zipArchive->renameName($this->targetPath . $this->ts . '-ident' . $this->fileExt, 'identifiers' . $this->fileExt);
+			}
 			//Meta file
 			$this->writeMetaFile();
 			$zipArchive->addFile($this->targetPath . $this->ts . '-meta.xml');
@@ -889,6 +897,7 @@ class DwcArchiverCore extends Manager{
 			if ($this->includeImgs) unlink($this->targetPath . $this->ts . '-multimedia' . $this->fileExt);
 			if ($this->includeAttributes && file_exists($this->targetPath . $this->ts . '-attr' . $this->fileExt)) unlink($this->targetPath . $this->ts . '-attr' . $this->fileExt);
 			if ($this->includeMaterialSample && file_exists($this->targetPath . $this->ts . '-matSample' . $this->fileExt)) unlink($this->targetPath . $this->ts . '-matSample' . $this->fileExt);
+			if ($this->includeIdentifiers && file_exists($this->targetPath . $this->ts . '-ident' . $this->fileExt)) unlink($this->targetPath . $this->ts . '-ident' . $this->fileExt);
 			unlink($this->targetPath . $this->ts . '-meta.xml');
 			if ($this->schemaType == 'dwc') rename($this->targetPath . $this->ts . '-eml.xml', $this->targetPath . str_replace('.zip', '.eml', $fileName));
 			else unlink($this->targetPath . $this->ts . '-eml.xml');
@@ -1084,6 +1093,36 @@ class DwcArchiverCore extends Manager{
 			}
 			$rootElem->appendChild($extElem3);
 		}
+
+		//Identifier extension  https://rs.gbif.org/extension/gbif/1.0/identifier.xml
+		if ($this->includeIdentifiers && isset($this->fieldArrMap['identifier'])) {
+			$extElem3 = $newDoc->createElement('extension');
+			$extElem3->setAttribute('encoding', $this->charSetOut);
+			$extElem3->setAttribute('fieldsTerminatedBy', $this->delimiter);
+			$extElem3->setAttribute('linesTerminatedBy', '\n');
+			$extElem3->setAttribute('fieldsEnclosedBy', '"');
+			$extElem3->setAttribute('ignoreHeaderLines', '1');
+			$extElem3->setAttribute('rowType', 'http://rs.gbif.org/terms/1.0/Identifier');
+
+			$filesElem3 = $newDoc->createElement('files');
+			$filesElem3->appendChild($newDoc->createElement('location', 'identifiers' . $this->fileExt));
+			$extElem3->appendChild($filesElem3);
+
+			$coreIdElem3 = $newDoc->createElement('coreid');
+			$coreIdElem3->setAttribute('index', '0');
+			$extElem3->appendChild($coreIdElem3);
+
+			$mofCnt = 1;
+			foreach ($this->fieldArrMap['identifier'] as $term) {
+				$fieldElem = $newDoc->createElement('field');
+				$fieldElem->setAttribute('index', $mofCnt);
+				$fieldElem->setAttribute('term', $term);
+				$extElem3->appendChild($fieldElem);
+				$mofCnt++;
+			}
+			$rootElem->appendChild($extElem3);
+		}
+
 		$newDoc->save($this->targetPath . $this->ts . '-meta.xml');
 
 		$this->logOrEcho('Done! (' . date('h:i:s A') . ")\n", 1);
@@ -1197,7 +1236,7 @@ class DwcArchiverCore extends Manager{
 				}
 			}
 		}
-		$emlArr = $this->utf8EncodeArr($emlArr);
+		$this->encodeArr($emlArr);
 		return $emlArr;
 	}
 
@@ -1395,7 +1434,7 @@ class DwcArchiverCore extends Manager{
 		//Collection data
 		if (array_key_exists('collMetadata', $emlArr)) {
 			foreach ($emlArr['collMetadata'] as $k => $collArr) {
-				$collArr = $this->utf8EncodeArr($collArr);
+				$this->encodeArr($collArr);
 				$collElem = $newDoc->createElement('collection');
 				if (isset($collArr['attr']) && $collArr['attr']) {
 					$attrArr = $collArr['attr'];
@@ -1520,7 +1559,8 @@ class DwcArchiverCore extends Manager{
 			'ORDER BY c.SortSeq, c.CollectionName';
 		$rs = $this->conn->query($sql);
 		while ($r = $rs->fetch_assoc()) {
-			$cArr = $this->utf8EncodeArr($r);
+			$cArr = $r;
+			$this->encodeArr($cArr);
 			$itemElem = $newDoc->createElement('item');
 			$itemAttr = $newDoc->createAttribute('collid');
 			$itemAttr->value = $cArr['collid'];
@@ -1772,6 +1812,7 @@ class DwcArchiverCore extends Manager{
 				if (count($batchOccidArr) > 10000) {
 					if ($this->includeAttributes) $this->writeAttributeData($batchOccidArr);
 					if ($this->includeMaterialSample) $this->writeMaterialSampleData($batchOccidArr);
+					if ($this->includeIdentifiers) $this->writeIdentifierData($batchOccidArr);
 					if ($pubID && $portalManager) $portalManager->insertPortalOccurrences($pubID, $batchOccidArr);
 					unset($batchOccidArr);
 					$batchOccidArr = array();
@@ -1796,6 +1837,10 @@ class DwcArchiverCore extends Manager{
 				$this->writeMaterialSampleData($batchOccidArr);
 				unset($this->materialSampleHandler);
 			}
+			if ($this->includeIdentifiers){
+				$this->writeIdentifierData($batchOccidArr);
+				unset($this->identierHandler);
+			}
 		}
 		else {
 			$this->errorMessage = 'ERROR creating occurrence file: ' . $this->conn->error;
@@ -1813,6 +1858,7 @@ class DwcArchiverCore extends Manager{
 		$this->logOrEcho('Done! (' . date('h:i:s A') . ")\n", 1);
 		if ($this->includeAttributes) $this->logOrEcho('Occurrence Attributes exported as a MeasurementsOrFact extension file... ');
 		if ($this->includeMaterialSample) $this->logOrEcho('Material Samples exported within a MaterialSample extension file... ');
+		if ($this->includeIdentifiers) $this->logOrEcho('Occurrence Alternative Identifiers exported as a Identifier extension file... ');
 		return $filePath;
 	}
 
@@ -1974,8 +2020,8 @@ class DwcArchiverCore extends Manager{
 	private function writeAttributeData($batchOccidArr){
 		if(!$this->attributeHandler){
 			$this->attributeHandler = new DwcArchiverAttribute($this->conn);
-			$this->attributeHandler->initiateProcess($this->targetPath . $this->ts . '-attr' . $this->fileExt);
 			$this->attributeHandler->setSchemaType($this->schemaType);
+			$this->attributeHandler->initiateProcess($this->targetPath . $this->ts . '-attr' . $this->fileExt);
 			$this->fieldArrMap['attribute'] = $this->attributeHandler->getFieldArrTerms();
 		}
 		if($this->attributeHandler) $this->attributeHandler->writeOutRecordBlock($batchOccidArr);
@@ -1984,11 +2030,21 @@ class DwcArchiverCore extends Manager{
 	private function writeMaterialSampleData($batchOccidArr){
 		if(!$this->materialSampleHandler){
 			$this->materialSampleHandler = new DwcArchiverMaterialSample($this->conn);
-			$this->materialSampleHandler->initiateProcess($this->targetPath . $this->ts . '-matSample' . $this->fileExt);
 			$this->materialSampleHandler->setSchemaType($this->schemaType);
+			$this->materialSampleHandler->initiateProcess($this->targetPath . $this->ts . '-matSample' . $this->fileExt);
 			$this->fieldArrMap['materialSample'] = $this->materialSampleHandler->getFieldArrTerms();
 		}
 		if($this->materialSampleHandler) $this->materialSampleHandler->writeOutRecordBlock($batchOccidArr);
+	}
+
+	private function writeIdentifierData($batchOccidArr){
+		if(!$this->identierHandler){
+			$this->identierHandler = new DwcArchiverIdentifier($this->conn);
+			$this->identierHandler->setSchemaType($this->schemaType);
+			$this->identierHandler->initiateProcess($this->targetPath . $this->ts . '-ident' . $this->fileExt);
+			$this->fieldArrMap['identifier'] = $this->identierHandler->getFieldArrTerms();
+		}
+		if($this->identierHandler) $this->identierHandler->writeOutRecordBlock($batchOccidArr);
 	}
 
 	private function writeCitationFile(){
@@ -2011,7 +2067,7 @@ class DwcArchiverCore extends Manager{
 		}
 
 		$DEFAULT_TITLE = $GLOBALS['DEFAULT_TITLE'];
-		$SERVER_HOST = $this->getDomain();
+		$SERVER_HOST = GeneralUtil::getDomain();
 		$CLIENT_ROOT = $GLOBALS['CLIENT_ROOT'];
 
 		// Decides which citation format to use according to $citationVarArr
@@ -2058,7 +2114,7 @@ class DwcArchiverCore extends Manager{
 			include $GLOBALS['SERVER_ROOT'] . '/includes/citation' . $citationFormat . '_template.php';
 		}
 		$output .= ob_get_clean();
-		$output .= "\n\nFor more information on citation formats, please see the following page: " . $this->getDomain() . $GLOBALS['CLIENT_ROOT'] . "/includes/usagepolicy.php";
+		$output .= "\n\nFor more information on citation formats, please see the following page: " . GeneralUtil::getDomain() . $GLOBALS['CLIENT_ROOT'] . "/includes/usagepolicy.php";
 
 		fwrite($fh, $output);
 
@@ -2170,6 +2226,11 @@ class DwcArchiverCore extends Manager{
 		else $this->includeMaterialSample = false;
 	}
 
+	public function setIncludeIdentifiers($include){
+		if($include) $this->includeIdentifiers = true;
+		else $this->includeIdentifiers = false;
+	}
+
 	public function hasAttributes($collid = false){
 		$bool = false;
 		$sql = 'SELECT occid FROM tmattributes LIMIT 1';
@@ -2195,6 +2256,18 @@ class DwcArchiverCore extends Manager{
 		return $bool;
 	}
 
+	public function hasIdentifiers($collid = false){
+		$bool = false;
+		$sql = 'SELECT occid FROM omoccuridentifiers LIMIT 1';
+		if(is_numeric($collid)){
+			$sql = 'SELECT a.occid FROM omoccurrences o INNER JOIN omoccuridentifiers i ON o.occid = i.occid WHERE o.collid = ' . $collid . ' LIMIT 1';
+		}
+		$rs = $this->conn->query($sql);
+		if ($rs->num_rows) $bool = true;
+		$rs->free();
+		return $bool;
+	}
+
 	public function setRedactLocalities($redact){
 		$this->redactLocalities = $redact;
 	}
@@ -2212,11 +2285,11 @@ class DwcArchiverCore extends Manager{
 	}
 
 	public function setPublicationGuid($guid){
-		if(UuidFactory::is_valid($guid)) $this->publicationGuid = $guid;
+		if(UuidFactory::isValid($guid)) $this->publicationGuid = $guid;
 	}
 
 	public function setRequestPortalGuid($guid){
-		if(UuidFactory::is_valid($guid)) $this->requestPortalGuid = $guid;
+		if(UuidFactory::isValid($guid)) $this->requestPortalGuid = $guid;
 	}
 
 	public function setCharSetOut($cs){
@@ -2235,7 +2308,7 @@ class DwcArchiverCore extends Manager{
 		if ($domain) {
 			$this->serverDomain = $domain;
 		} elseif (!$this->serverDomain) {
-			$this->serverDomain = $this->getDomain();
+			$this->serverDomain = GeneralUtil::getDomain();
 		}
 	}
 
@@ -2244,28 +2317,16 @@ class DwcArchiverCore extends Manager{
 		return $this->serverDomain;
 	}
 
-	protected function utf8EncodeArr($inArr){
-		$retArr = $inArr;
-		if ($this->charSetSource == 'ISO-8859-1') {
-			foreach ($retArr as $k => $v) {
-				if (is_array($v)) {
-					$retArr[$k] = $this->utf8EncodeArr($v);
-				} elseif (is_string($v)) {
-					if (mb_detect_encoding($v, 'UTF-8,ISO-8859-1', true) == "ISO-8859-1") {
-						$retArr[$k] = utf8_encode($v);
-					}
-				} else {
-					$retArr[$k] = $v;
-				}
-			}
-		}
-		return $retArr;
-	}
-
-	private function encodeArr(&$inArr){
+	protected function encodeArr(&$inArr){
 		if ($this->charSetSource && $this->charSetOut != $this->charSetSource) {
 			foreach ($inArr as $k => $v) {
-				$inArr[$k] = $this->encodeStr($v);
+				if (is_array($v)) {
+					$this->encodeArr($v);
+					$inArr[$k] = $v;
+				}
+				else{
+					$inArr[$k] = $this->encodeStr($v);
+				}
 			}
 		}
 	}
@@ -2278,12 +2339,12 @@ class DwcArchiverCore extends Manager{
 					$retStr = mb_convert_encoding($inStr, 'UTF-8', 'ISO-8859-1');
 				}
 			} elseif ($this->charSetOut == 'ISO-8859-1' && $this->charSetSource == 'UTF-8') {
-				if (mb_detect_encoding($inStr, 'UTF-8,ISO-8859-1') == 'UTF-8') {
+				if (mb_detect_encoding($inStr, 'UTF-8,ISO-8859-1,ISO-8859-15') == 'UTF-8') {
 					$retStr = mb_convert_encoding($inStr, 'ISO-8859-1', 'UTF-8');
 				}
 			}
 			else{
-				$retStr = mb_convert_encoding($inStr, $this->charSetOut, mb_detect_encoding($inStr));
+				$retStr = mb_convert_encoding($inStr, $this->charSetOut, mb_detect_encoding($inStr, 'UTF-8,ISO-8859-1,ISO-8859-15'));
 			}
 		}
 		return $retStr;

--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -9,8 +9,7 @@ include_once($SERVER_ROOT . '/classes/DwcArchiverIdentifier.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceTaxaManager.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceAccessStats.php');
 include_once($SERVER_ROOT . '/classes/PortalIndex.php');
-include_once($SERVER_ROOT . '/classes/utilities/UuidFactory.php');
-include_once($SERVER_ROOT . '/classes/utilities/GeneralUtil.php');
+include_once($SERVER_ROOT . '/classes/UuidFactory.php');
 
 class DwcArchiverCore extends Manager{
 
@@ -440,7 +439,7 @@ class DwcArchiverCore extends Manager{
 			}
 			if (isset($dwcArray['occurrenceID']) || (isset($dwcArray['catalogNumber']) && isset($dwcArray['collectionCode']))) {
 				$occurrenceid = $dwcArray['occurrenceID'];
-				if (UuidFactory::isValid($occurrenceid)) {
+				if (UuidFactory::is_valid($occurrenceid)) {
 					$occurrenceid = "urn:uuid:$occurrenceid";
 				} else {
 					$catalogNumber = $dwcArray['catalogNumber'];
@@ -465,7 +464,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							case "collectionID":
 								// RDF Guide Section 2.3.3 owl:sameAs for urn:lsid and resolvable IRI.
-								if (stripos("urn:uuid:", $value) === false && UuidFactory::isValid($value)) {
+								if (stripos("urn:uuid:", $value) === false && UuidFactory::is_valid($value)) {
 									$lsid = "urn:uuid:$value";
 								} elseif (stripos("urn:lsid:biocol.org", $value) === 0) {
 									$lsid = "http://biocol.org/$value";
@@ -516,7 +515,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							default:
 								if (isset($occurTermArr[$key])) {
-									//$ns = RdfUtil::namespaceAbbrev($occurTermArr[$key]);
+									//$ns = RdfUtility::namespaceAbbrev($occurTermArr[$key]);
 									//$returnvalue .= $separator . "   " . $ns . " \"$value\"";
 								}
 						}
@@ -564,7 +563,7 @@ class DwcArchiverCore extends Manager{
 			}
 			if (isset($dwcArray['occurrenceID']) || (isset($dwcArray['catalogNumber']) && isset($dwcArray['collectionCode']))) {
 				$occurrenceid = $dwcArray['occurrenceID'];
-				if (UuidFactory::isValid($occurrenceid)) {
+				if (UuidFactory::is_valid($occurrenceid)) {
 					$occurrenceid = "urn:uuid:$occurrenceid";
 				} else {
 					$catalogNumber = $dwcArray['catalogNumber'];
@@ -595,7 +594,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							case "collectionID":
 								// RDF Guide Section 2.3.3 owl:sameAs for urn:lsid and resolvable IRI.
-								if (stripos("urn:uuid:", $value) === false && UuidFactory::isValid($value)) {
+								if (stripos("urn:uuid:", $value) === false && UuidFactory::is_valid($value)) {
 									$lsid = "urn:uuid:$value";
 								} elseif (stripos("urn:lsid:biocol.org", $value) === 0) {
 									$lsid = "http://biocol.org/$value";
@@ -653,7 +652,7 @@ class DwcArchiverCore extends Manager{
 								break;
 							default:
 								if (isset($occurTermArr[$key])) {
-									//$ns = RdfUtil::namespaceAbbrev($occurTermArr[$key]);
+									//$ns = RdfUtility::namespaceAbbrev($occurTermArr[$key]);
 									//$elem = $newDoc->createElement($ns);
 									//$elem->appendChild($newDoc->createTextNode($value));
 								}
@@ -2067,7 +2066,7 @@ class DwcArchiverCore extends Manager{
 		}
 
 		$DEFAULT_TITLE = $GLOBALS['DEFAULT_TITLE'];
-		$SERVER_HOST = GeneralUtil::getDomain();
+		$SERVER_HOST = $this->getDomain();
 		$CLIENT_ROOT = $GLOBALS['CLIENT_ROOT'];
 
 		// Decides which citation format to use according to $citationVarArr
@@ -2114,7 +2113,7 @@ class DwcArchiverCore extends Manager{
 			include $GLOBALS['SERVER_ROOT'] . '/includes/citation' . $citationFormat . '_template.php';
 		}
 		$output .= ob_get_clean();
-		$output .= "\n\nFor more information on citation formats, please see the following page: " . GeneralUtil::getDomain() . $GLOBALS['CLIENT_ROOT'] . "/includes/usagepolicy.php";
+		$output .= "\n\nFor more information on citation formats, please see the following page: " . $this->getDomain() . $GLOBALS['CLIENT_ROOT'] . "/includes/usagepolicy.php";
 
 		fwrite($fh, $output);
 
@@ -2285,11 +2284,11 @@ class DwcArchiverCore extends Manager{
 	}
 
 	public function setPublicationGuid($guid){
-		if(UuidFactory::isValid($guid)) $this->publicationGuid = $guid;
+		if(UuidFactory::is_valid($guid)) $this->publicationGuid = $guid;
 	}
 
 	public function setRequestPortalGuid($guid){
-		if(UuidFactory::isValid($guid)) $this->requestPortalGuid = $guid;
+		if(UuidFactory::is_valid($guid)) $this->requestPortalGuid = $guid;
 	}
 
 	public function setCharSetOut($cs){
@@ -2308,7 +2307,7 @@ class DwcArchiverCore extends Manager{
 		if ($domain) {
 			$this->serverDomain = $domain;
 		} elseif (!$this->serverDomain) {
-			$this->serverDomain = GeneralUtil::getDomain();
+			$this->serverDomain = $this->getDomain();
 		}
 	}
 

--- a/classes/DwcArchiverDetermination.php
+++ b/classes/DwcArchiverDetermination.php
@@ -47,14 +47,11 @@ class DwcArchiverDetermination{
 	private static function trimBySchemaType($detArr,$schemaType,$extended){
 		$trimArr = array();
 		if($schemaType == 'dwc'){
-			$trimArr = array('identifiedByID');
-			$trimArr = array('tidInterpreted');
-			$trimArr = array('identificationIsCurrent');
+			$trimArr = array('identifiedByID', 'tidInterpreted', 'identificationIsCurrent');
 		}
 		elseif($schemaType == 'symbiota'){
 			if(!$extended){
-				$trimArr = array('identifiedByID');
-				$trimArr = array('tidInterpreted');
+				$trimArr = array('identifiedByID', 'tidInterpreted');
 			}
 		}
 		elseif($schemaType == 'backup'){

--- a/classes/DwcArchiverIdentifier.php
+++ b/classes/DwcArchiverIdentifier.php
@@ -1,0 +1,65 @@
+<?php
+include_once($SERVER_ROOT . '/classes/DwcArchiverBaseManager.php');
+
+class DwcArchiverIdentifier extends DwcArchiverBaseManager{
+
+	public function __construct($connOverride){
+		parent::__construct('write', $connOverride);
+	}
+
+	public function __destruct(){
+		parent::__destruct();
+	}
+
+	public function initiateProcess($filePath){
+		$this->setFieldArr();
+		$this->setSqlBase();
+
+		$this->setFileHandler($filePath);
+	}
+
+	//Based on https://rs.gbif.org/extension/gbif/1.0/identifier.xml
+	private function setFieldArr(){
+		$columnArr = array();
+		$columnArr['coreid'] = 'occid';
+		$termArr['identifier'] = 'http://purl.org/dc/terms/identifier';
+		$columnArr['identifier'] = 'identifierValue';
+		$termArr['title'] = 'http://purl.org/dc/terms/title';
+		$columnArr['title'] = 'identifierName';
+		$termArr['format'] = 'http://purl.org/dc/terms/format';
+		$columnArr['format'] = 'format';
+		$termArr['notes'] = 'https://symbiota.org/terms/identifier/notes';
+		$columnArr['notes'] = 'notes';
+		$termArr['sortBy'] = 'https://symbiota.org/terms/identifier/sortBy';
+		$columnArr['sortBy'] = 'sortBy';
+ 		$termArr['recordID'] = 'https://symbiota.org/terms/identifier/recordID';
+ 		$columnArr['recordID'] = 'recordID';
+		$termArr['initialTimestamp'] = 'https://symbiota.org/terms/identifier/initialTimestamp';
+		$columnArr['initialTimestamp'] = 'initialTimestamp';
+
+		$this->fieldArr['terms'] = $this->trimBySchemaType($termArr);
+		$this->fieldArr['fields'] = $this->trimBySchemaType($columnArr);
+	}
+
+	private function trimBySchemaType($dataArr){
+		$trimArr = array();
+		if($this->schemaType == 'backup'){
+			//$trimArr = array();
+		}
+		elseif($this->schemaType == 'dwc'){
+			$trimArr = array('notes', 'sortBy');
+		}
+		return array_diff_key($dataArr, array_flip($trimArr));
+	}
+
+	private function setSqlBase(){
+		if($this->fieldArr){
+			$sqlFrag = '';
+			foreach($this->fieldArr['fields'] as $colName){
+				if($colName) $sqlFrag .= ', ' . $colName;
+			}
+			$this->sqlBase = 'SELECT ' . trim($sqlFrag, ', ') . ' FROM omoccuridentifiers ';
+		}
+	}
+}
+?>

--- a/classes/DwcArchiverPublisher.php
+++ b/classes/DwcArchiverPublisher.php
@@ -53,6 +53,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 		$successArr = array();
 		$includeAttributes = $this->includeAttributes;
 		$includeMatSample = $this->includeMaterialSample;
+		$includeIdentifiers = $this->includeIdentifiers;
 		foreach($collIdArr as $id){
 			//Create a separate DWCA object for each collection
 			if($includeAttributes){
@@ -62,6 +63,10 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 			if($includeMatSample){
 				if($this->hasMaterialSamples($id)) $this->includeMaterialSample = true;
 				else $this->includeMaterialSample = false;
+			}
+			if($includeIdentifiers){
+				if($this->hasIdentifiers($id)) $this->includeIdentifiers = true;
+				else $this->includeIdentifiers = false;
 			}
 			$this->resetCollArr($id);
 			$this->conditionArr['collid'] = $id;
@@ -73,6 +78,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 		}
 		$this->includeAttributes = $includeAttributes;
 		$this->includeMaterialSample = $includeMatSample;
+		$this->includeIdentifiers = $includeIdentifiers;
 		//Reset $this->collArr with all the collections ran successfully and then rebuild the RSS feed
 		$this->resetCollArr(implode(',',$successArr));
 		$this->writeRssFile();
@@ -118,7 +124,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 		//Create new item for target archives and load into array
 		$itemArr = array();
 		foreach($this->collArr as $collID => $cArr){
-			$cArr = $this->utf8EncodeArr($cArr);
+			$this->encodeArr($cArr);
 			$itemElem = $newDoc->createElement('item');
 			$itemAttr = $newDoc->createAttribute('collid');
 			$itemAttr->value = $collID;
@@ -210,7 +216,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 
 		if($sourcePath == $deprecatedPath || !file_exists($deprecatedPath)){
 			$redirectDoc = new DOMDocument();
-			$redirectDoc->loadXML('<redirect><newLocation>'.$this->getDomain().$GLOBALS['CLIENT_ROOT'].'/content/dwca/rss.xml</newLocation></redirect>');
+			$redirectDoc->loadXML('<redirect><newLocation>' . GeneralUtil::getDomain() . $GLOBALS['CLIENT_ROOT'] . '/content/dwca/rss.xml</newLocation></redirect>');
 			$redirectDoc->save($deprecatedPath);
 		}
 
@@ -253,7 +259,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 
 	public function getCollectionList($catID){
 		$retArr = array();
-		$serverName = $this->getDomain();
+		$serverName = GeneralUtil::getDomain();
 		$sql = 'SELECT c.collid, c.collectionname, CONCAT_WS("-",c.institutioncode,c.collectioncode) as instcode, c.guidtarget, c.dwcaurl, c.managementtype, c.dynamicProperties '.
 			'FROM omcollections c INNER JOIN omcollectionstats s ON c.collid = s.collid '.
 			'LEFT JOIN omcollcatlink l ON c.collid = l.collid '.

--- a/classes/DwcArchiverPublisher.php
+++ b/classes/DwcArchiverPublisher.php
@@ -216,7 +216,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 
 		if($sourcePath == $deprecatedPath || !file_exists($deprecatedPath)){
 			$redirectDoc = new DOMDocument();
-			$redirectDoc->loadXML('<redirect><newLocation>' . GeneralUtil::getDomain() . $GLOBALS['CLIENT_ROOT'] . '/content/dwca/rss.xml</newLocation></redirect>');
+			$redirectDoc->loadXML('<redirect><newLocation>' . $this->getDomain() . $GLOBALS['CLIENT_ROOT'] . '/content/dwca/rss.xml</newLocation></redirect>');
 			$redirectDoc->save($deprecatedPath);
 		}
 
@@ -259,7 +259,7 @@ class DwcArchiverPublisher extends DwcArchiverCore{
 
 	public function getCollectionList($catID){
 		$retArr = array();
-		$serverName = GeneralUtil::getDomain();
+		$serverName = $this->getDomain();
 		$sql = 'SELECT c.collid, c.collectionname, CONCAT_WS("-",c.institutioncode,c.collectioncode) as instcode, c.guidtarget, c.dwcaurl, c.managementtype, c.dynamicProperties '.
 			'FROM omcollections c INNER JOIN omcollectionstats s ON c.collid = s.collid '.
 			'LEFT JOIN omcollcatlink l ON c.collid = l.collid '.

--- a/collections/datasets/datapublisher.php
+++ b/collections/datasets/datapublisher.php
@@ -2,6 +2,8 @@
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT . '/classes/DwcArchiverPublisher.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceCollectionProfile.php');
+include_once($SERVER_ROOT . '/classes/utilities/GeneralUtil.php');
+
 if ($LANG_TAG != 'en' && file_exists($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.en.php');
 header('Content-Type: text/html; charset=' . $CHARSET);
@@ -33,6 +35,7 @@ $includeDets = 1;
 $includeImgs = 1;
 $includeAttributes = 1;
 $includeMatSample = 1;
+$includeIdentifiers = 1;
 $redactLocalities = 1;
 
 if ($action == 'savekey' || (isset($_REQUEST['datasetKey']) && $_REQUEST['datasetKey'])) {
@@ -48,6 +51,8 @@ elseif ($action) {
 	$dwcaManager->setIncludeAttributes($includeAttributes);
 	if (!array_key_exists('matsample', $_POST)) $includeMatSample = 0;
 	$dwcaManager->setIncludeMaterialSample($includeMatSample);
+	if (!array_key_exists('identifiers', $_POST)) $includeIdentifiers = 0;
+	$dwcaManager->setIncludeIdentifiers($includeIdentifiers);
 	if (!array_key_exists('redact', $_POST)) $redactLocalities = 0;
 	$dwcaManager->setRedactLocalities($redactLocalities);
 	$dwcaManager->setTargetPath($SERVER_ROOT . (substr($SERVER_ROOT, -1) == '/' ? '' : '/') . 'content/dwca/');
@@ -195,15 +200,15 @@ if ($isEditor) {
 	include($SERVER_ROOT . '/includes/header.php');
 	?>
 	<div class='navpath'>
-		<a href="../../index.php"><?php echo htmlspecialchars($LANG['HOME'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+		<a href="../../index.php"><?php echo $LANG['HOME']; ?></a> &gt;&gt;
 		<?php
 		if ($collid) {
 			?>
-			<a href="../misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>&emode=1"><?php echo htmlspecialchars($LANG['COL_MANAGEMENT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+			<a href="../misc/collprofiles.php?collid=<?php echo htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>&emode=1"><?php echo $LANG['COL_MANAGEMENT']; ?></a> &gt;&gt;
 			<?php
 		} else {
 			?>
-			<a href="../../sitemap.php"><?php echo htmlspecialchars($LANG['SITEMAP'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a> &gt;&gt;
+			<a href="../../sitemap.php"><?php echo $LANG['SITEMAP']; ?></a> &gt;&gt;
 			<?php
 		}
 		?>
@@ -215,8 +220,8 @@ if ($isEditor) {
 		if (!$collid && $IS_ADMIN) {
 			?>
 			<div style="float:right;">
-				<a href="#" title="<?php echo htmlspecialchars($LANG['DISPLAY_CONTROL_PANEL'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" onclick="toggle('dwcaadmindiv')">
-					<?php echo $LANG['EDIT'] ?> 
+				<a href="#" title="<?php echo $LANG['DISPLAY_CONTROL_PANEL']; ?>" onclick="toggle('dwcaadmindiv')">
+					<?php echo $LANG['EDIT'] ?>
 					<img style="border:0;width:1.2em;" src="../../images/edit.png" alt="pencil icon to indicate edit mode toggle" />
 				</a>
 			</div>
@@ -229,9 +234,9 @@ if ($isEditor) {
 			<div class="font-control top-breathing-room-rel">
 				<?php
 				echo $LANG['DWCA_EXPLAIN_1'] . ' <a href="https://en.wikipedia.org/wiki/Darwin_Core_Archive" target="_blank">' . $LANG['DWCA'] . '</a> ' . $LANG['DWCA_EXPLAIN_2'] .
-					' <a href="http://rs.tdwg.org/dwc/terms/" target="_blank">' . htmlspecialchars($LANG['DWC'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['DWCA_EXPLAIN_3'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) .
-					' <a href="https://biokic.github.io/symbiota-docs/coll_manager/data_publishing/idigbio/" target="_blank"> ' . htmlspecialchars($LANG['PUBLISH_IDIGBIO'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> &amp;' .
-					' <a href="https://biokic.github.io/symbiota-docs/coll_manager/data_publishing/gbif/" target="_blank"> ' . htmlspecialchars($LANG['PUBLISH_GBIF'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>.';
+					' <a href="http://rs.tdwg.org/dwc/terms/" target="_blank">' . $LANG['DWC'] . '</a> ' . $LANG['DWCA_EXPLAIN_3'] .
+					' <a href="https://biokic.github.io/symbiota-docs/coll_manager/data_publishing/idigbio/" target="_blank"> ' . $LANG['PUBLISH_IDIGBIO'] . '</a> &amp;' .
+					' <a href="https://biokic.github.io/symbiota-docs/coll_manager/data_publishing/gbif/" target="_blank"> ' . $LANG['PUBLISH_GBIF'] . '</a>.';
 				?>
 			</div>
 			<?php
@@ -239,14 +244,14 @@ if ($isEditor) {
 			?>
 			<div>
 				<?php
-				echo $LANG['DWCA_DOWNLOAD_EXPLAIN_1'] . ' <a href="https://en.wikipedia.org/wiki/Darwin_Core_Archive" target="_blank">' . htmlspecialchars($LANG['DWCA'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ';
-				echo $LANG['DWCA_DOWNLOAD_EXPLAIN_2'] . ' <a href="http://rs.tdwg.org/dwc/terms/" target="_blank">' . htmlspecialchars($LANG['DWC'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['DWCA_DOWNLOAD_EXPLAIN_3'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+				echo $LANG['DWCA_DOWNLOAD_EXPLAIN_1'] . ' <a href="https://en.wikipedia.org/wiki/Darwin_Core_Archive" target="_blank">' . $LANG['DWCA'] . '</a> ';
+				echo $LANG['DWCA_DOWNLOAD_EXPLAIN_2'] . ' <a href="http://rs.tdwg.org/dwc/terms/" target="_blank">' . $LANG['DWC'] . '</a> ' . $LANG['DWCA_DOWNLOAD_EXPLAIN_3'];
 				?>
 			</div>
 			<div>
 				<?php
 				echo '<h2>' . $LANG['DATA_USE_POLICY'] . ':</h2>';
-				echo $LANG['DATA_POLICY_1'] . ' <a href="../../includes/usagepolicy.php">' . htmlspecialchars($LANG['DATA_USE_POLICY'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>. ' . htmlspecialchars($LANG['DATA_POLICY_2'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+				echo $LANG['DATA_POLICY_1'] . ' <a href="../../includes/usagepolicy.php">' . $LANG['DATA_USE_POLICY'] . '</a>. ' . $LANG['DATA_POLICY_2'];
 				?>
 			</div>
 			<?php
@@ -258,7 +263,7 @@ if ($isEditor) {
 			$urlPrefix = $dwcaManager->getServerDomain() . $CLIENT_ROOT . (substr($CLIENT_ROOT, -1) == '/' ? '' : '/');
 			if (file_exists('../../content/dwca/rss.xml')) {
 				$feedLink = $urlPrefix . 'content/dwca/rss.xml';
-				echo '<a href="' . htmlspecialchars($feedLink, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" target="_blank">' . htmlspecialchars($feedLink, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>';
+				echo '<a href="' . $feedLink . '" target="_blank">' . $feedLink . '</a>';
 			} else {
 				echo '--' . $LANG['FEED_NOT_PUBLISHED'] . '--';
 			}
@@ -308,7 +313,7 @@ if ($isEditor) {
 					<?php
 					$emlLink = $urlPrefix . 'collections/datasets/emlhandler.php?collid=' . $collid;
 					?>
-					<div><b>EML:</b> <a href="<?php echo htmlspecialchars($emlLink, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>" target="_blank"><?php echo htmlspecialchars($emlLink, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a></div>
+					<div><b>EML:</b> <a href="<?= $emlLink; ?>" target="_blank"><?= $emlLink ?></a></div>
 					<div><b><?php echo $LANG['DWCA_FILE']; ?>:</b> <a href="<?php echo htmlspecialchars($dArr['link'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?>"><?php echo htmlspecialchars($dArr['link'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE); ?></a></div>
 					<div><b><?php echo $LANG['PUB_DATE']; ?>:</b> <?php echo $dArr['pubDate']; ?></div>
 				</div>
@@ -326,19 +331,19 @@ if ($isEditor) {
 					if (isset($recFlagArr['nullGUIDs']) && $recFlagArr['nullGUIDs']) {
 						echo '<div class="font-control">';
 						if ($collArr['guidtarget'] == 'occurrenceId') {
-							echo '<b>' . $LANG['RECORDS_MISSING'] . ' <a href="https://dwc.tdwg.org/terms/#dwc:occurrenceID" target="_blank">' . htmlspecialchars($LANG['OCCID_GUIDS'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>:</b> ' . htmlspecialchars($recFlagArr['nullGUIDs'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+							echo '<b>' . $LANG['RECORDS_MISSING'] . ' <a href="https://dwc.tdwg.org/terms/#dwc:occurrenceID" target="_blank">' . $LANG['OCCID_GUIDS'] . '</a>:</b> ' . htmlspecialchars($recFlagArr['nullGUIDs'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
 							echo ' <span style="color:red;margin-left:15px;">' . $LANG['RECS_TO_NOT_PUBLISH'] . '</span> ';
 						} elseif ($collArr['guidtarget'] == 'catalogNumber') {
 							echo '<b>' . $LANG['RECS_WO_CATNUMS'] . ':</b> ' . $recFlagArr['nullGUIDs'];
 							echo ' <span style="color:red;margin-left:15px;">' . $LANG['RECS_WILL_NOT_PUBLISH'] . '</span> ';
 						} else {
 							echo $LANG['RECS_MISSING_GUIDS'] . ': ' . $recFlagArr['nullGUIDs'] . '<br/>';
-							echo $LANG['PLEASE_GO_TO'] . ' <a href="../admin/guidmapper.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . htmlspecialchars($LANG['COLL_GUID_MAP'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['TO_ASSIGN_GUIDS'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+							echo $LANG['PLEASE_GO_TO'] . ' <a href="../admin/guidmapper.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . $LANG['COLL_GUID_MAP'] . '</a> ' . $LANG['TO_ASSIGN_GUIDS'];
 						}
 						echo '</div>';
 					}
 					if ($collArr['dwcaurl']) {
-						$serverName = $collManager->getDomain();
+						$serverName = GeneralUtil::getDomain();
 						if(substr($serverName, 0, 4) == 'www.') $serverName = str_replace('www.', '', $serverName);
 						if(!strpos($serverName, 'localhost') && strpos($collArr['dwcaurl'], $serverName) === false) {
 							$baseUrl = substr($collArr['dwcaurl'], 0, strpos($collArr['dwcaurl'], '/content')) . '/collections/datasets/datapublisher.php';
@@ -346,11 +351,11 @@ if ($isEditor) {
 						}
 					}
 				} else {
-					echo '<div style="margin:10px;font-weight:bold;color:red;" class="font-control top-breathing-room-rel">' . $LANG['GUID_NOT_SET'] . ' <a href="../misc/collmetadata.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . htmlspecialchars($LANG['EDIT_METADATA'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['TO_SET_GUID'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '.</div>';
+					echo '<div style="margin:10px;font-weight:bold;color:red;" class="font-control top-breathing-room-rel">' . $LANG['GUID_NOT_SET'] . ' <a href="../misc/collmetadata.php?collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . $LANG['EDIT_METADATA'] . '</a> ' . $LANG['TO_SET_GUID'] . '.</div>';
 					$blockSubmitMsg = $LANG['CANNOT_PUBLISH'] . '<br/>';
 				}
 				if ($recFlagArr['nullBasisRec']) {
-					echo '<div style="margin:10px;font-weight:bold;color:red;" class="font-control top-breathing-room-rel">' . $LANG['THERE_ARE'] . ' ' . $recFlagArr['nullBasisRec'] . $LANG['MISSING_BASISOFRECORD'] . ' ' . ' <a href="../editor/occurrencetabledisplay.php?q_recordedby=&q_recordnumber=&q_catalognumber&collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&csmode=0&occid=&occindex=0">' . htmlspecialchars($LANG['EDIT_EXISTING'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['TO_CORRECT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</div>';
+					echo '<div style="margin:10px;font-weight:bold;color:red;" class="font-control top-breathing-room-rel">' . $LANG['THERE_ARE'] . ' ' . $recFlagArr['nullBasisRec'] . $LANG['MISSING_BASISOFRECORD'] . ' ' . ' <a href="../editor/occurrencetabledisplay.php?q_recordedby=&q_recordnumber=&q_catalognumber&collid=' . htmlspecialchars($collid, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '&csmode=0&occid=&occindex=0">' . $LANG['EDIT_EXISTING'] . '</a> ' . $LANG['TO_CORRECT'] . '</div>';
 				}
 				if ($publishGBIF && $dwcUri && isset($GBIF_USERNAME) && isset($GBIF_PASSWORD) && isset($GBIF_ORG_KEY) && $GBIF_ORG_KEY) {
 					if ($collManager->getDatasetKey()) {
@@ -365,7 +370,7 @@ if ($isEditor) {
 						<div>
 							<?php
 							echo $LANG['YOU_SELECTED_GBIF_1'] .
-							' <a href="https://www.gbif.org/become-a-publisher" target="_blank">' . htmlspecialchars($LANG['GBIF_ENDORSE'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) .
+							' <a href="https://www.gbif.org/become-a-publisher" target="_blank">' . $LANG['GBIF_ENDORSE'] .
 							'</a> ' . $LANG['TO'] . ' ' . $LANG['YOU_SELECTED_GBIF_2'];
 							?>
 							<form style="margin-top:10px;" name="gbifpubform" action="datapublisher.php" method="post" onsubmit="return validateGbifForm(this)">
@@ -385,7 +390,7 @@ if ($isEditor) {
 									?>
 									<div style="margin:10px 0px;clear:both;">
 										<?php
-										$collPath = $collManager->getDomain() . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $collid;
+										$collPath = GeneralUtil::getDomain() . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $collid;
 										$bodyStr = 'Please provide the following GBIF user permission to create and update datasets for the following GBIF publisher.<br/>' .
 											'Once these permissions are assigned, we will be pushing a DwC-Archive from the following Symbiota collection to GBIF.<br/><br/>' .
 											'GBIF user: ' . $GBIF_USERNAME . '<br/>' .
@@ -396,7 +401,7 @@ if ($isEditor) {
 										echo $LANG['BEFORE_SUBMITTING'];
 										echo ' (<a href="mailto:helpdesk@gbif.org?subject=Publishing%20data%20from%20Symbiota%20portal%20to%20GBIF...&body=' . rawurlencode(str_replace('<br/>', "\n", $bodyStr)) . '">helpdesk@gbif.org</a>) ';
 										echo $LANG['WITH_REQUEST_1'] . ' &quot;<b>' . $GBIF_USERNAME . '</b>&quot; ' . $LANG['WITH_REQUEST_2'];
-										echo ' <a href="#" onclick="toggle(\'emailMsg\');return false;" style="color:blue">' . htmlspecialchars($LANG['HERE'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ' . htmlspecialchars($LANG['WITH_REQUEST_3'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+										echo ' <a href="#" onclick="toggle(\'emailMsg\');return false;" style="color:blue">' . $LANG['HERE'] . '</a> ' . $LANG['WITH_REQUEST_3'];
 										?>
 										<fieldset id="emailMsg" style="display:none;padding:15px;margin:15px">
 											<legend><?php echo $LANG['EMAIL_DRAFT']; ?></legend><?php echo trim($bodyStr, ' <br/>'); ?>
@@ -432,6 +437,7 @@ if ($isEditor) {
 						<?php
 						if($dwcaManager->hasAttributes($collid)) echo '<input type="checkbox" name="attributes" value="1" '.($includeAttributes ? 'CHECKED' : '').'> '.$LANG['INCLUDE_ATTRIBUTES'].'<br/>';
 						if($dwcaManager->hasMaterialSamples($collid)) echo '<input type="checkbox" name="matsample" value="1" '.($includeMatSample ? 'CHECKED' : '').'> '.$LANG['INCLUDE_MATSAMPLE'].'<br/>';
+						if($dwcaManager->hasIdentifiers($collid)) echo '<input type="checkbox" name="identifiers" value="1" '.($includeIdentifiers ? 'CHECKED' : '').'> '.$LANG['INCLUDE_IDENTIFIERS'].'<br/>';
 						?>
 					</div>
 					<div style="margin-top:5px;" class="font-control top-breathing-room-rel">
@@ -476,6 +482,10 @@ if ($isEditor) {
 								if($dwcaManager->hasMaterialSamples($id)) $dwcaManager->setIncludeMaterialSample(1);
 								else  $dwcaManager->setIncludeMaterialSample(0);
 							}
+							if($includeIdentifiers){
+								if($dwcaManager->hasIdentifiers($id)) $dwcaManager->setIncludeIdentifiers(1);
+								else $dwcaManager->setIncludeIdentifiers(0);
+							}
 							if($dwcaManager->createDwcArchive()){
 								$dwcaManager->writeRssFile();
 								$collManager->batchTriggerGBIFCrawl(array($id));
@@ -483,6 +493,7 @@ if ($isEditor) {
 						}
 						$dwcaManager->setIncludeAttributes($includeAttributes);
 						$dwcaManager->setIncludeMaterialSample($includeMatSample);
+						$dwcaManager->setIncludeIdentifiers($includeIdentifiers);
 						echo '</ul>';
 						echo 'Batch process finished! (' . date('Y-m-d h:i:s A') . ')';
 					}
@@ -507,7 +518,7 @@ if ($isEditor) {
 									elseif ($v['url']) $inputAttr = 'CHECKED';
 									echo '<div class="bottom-breathing-room">';
 									echo '<input class="margin-rt-rel" name="coll[]" type="checkbox" value="' . $k . '" ' . $inputAttr . ' />';
-									echo '<a href="../misc/collprofiles.php?collid=' . htmlspecialchars($k, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '" target="_blank">' . htmlspecialchars($v['name'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ';
+									echo '<a href="../misc/collprofiles.php?collid=' . $k . '" target="_blank">' . htmlspecialchars($v['name'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a> ';
 									if ($errMsg) echo '<span style="color:red;margin-left:15px;">' . $errMsg . '</span>';
 									elseif ($v['url']) echo '<span> - published</span>';
 									echo '</div>';
@@ -523,6 +534,7 @@ if ($isEditor) {
 									<?php
 									if($dwcaManager->hasAttributes()) echo '<input type="checkbox" name="attributes" value="1" '.($includeAttributes ? 'CHECKED' : '').'> '.$LANG['INCLUDE_ATTRIBUTES'].'<br/>';
 									if($dwcaManager->hasMaterialSamples()) echo '<input type="checkbox" name="matsample" value="1" '.($includeMatSample ? 'CHECKED' : '').'> '.$LANG['INCLUDE_MATSAMPLE'].'<br/>';
+									if($dwcaManager->hasIdentifiers()) echo '<input type="checkbox" name="identifiers" value="1" '.($includeIdentifiers ? 'CHECKED' : '').'> '.$LANG['INCLUDE_IDENTIFIERS'].'<br/>';
 									?>
 								</div>
 								<div style="margin-top:5px;">
@@ -552,7 +564,7 @@ if ($isEditor) {
 					foreach ($dwcaArr as $k => $v) {
 						?>
 						<tr>
-							<td><?php echo '<a href="../misc/collprofiles.php?collid=' . htmlspecialchars($v['collid'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . htmlspecialchars(str_replace(' DwC-Archive', '', $v['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>'; ?></td>
+							<td><?php echo '<a href="../misc/collprofiles.php?collid=' . $v['collid'] . '">' . htmlspecialchars(str_replace(' DwC-Archive', '', $v['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '</a>'; ?></td>
 							<td><?php echo substr($v['description'], 24); ?></td>
 							<td class="nowrap">
 								<?php
@@ -569,7 +581,7 @@ if ($isEditor) {
 							</td>
 							<td>
 								<?php
-								echo '<a href="' . htmlspecialchars($urlPrefix, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . 'collections/datasets/emlhandler.php?collid=' . htmlspecialchars($v['collid'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">EML</a>';
+								echo '<a href="' . $urlPrefix . 'collections/datasets/emlhandler.php?collid=' . $v['collid'] . '">EML</a>';
 								?>
 							</td>
 							<td class="nowrap"><?php echo date('Y-m-d', strtotime($v['pubDate'])); ?></td>

--- a/collections/datasets/datapublisher.php
+++ b/collections/datasets/datapublisher.php
@@ -2,7 +2,6 @@
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT . '/classes/DwcArchiverPublisher.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceCollectionProfile.php');
-include_once($SERVER_ROOT . '/classes/utilities/GeneralUtil.php');
 
 if ($LANG_TAG != 'en' && file_exists($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT . '/content/lang/collections/datasets/datapublisher.en.php');
@@ -343,7 +342,7 @@ if ($isEditor) {
 						echo '</div>';
 					}
 					if ($collArr['dwcaurl']) {
-						$serverName = GeneralUtil::getDomain();
+						$serverName = $collManager->getDomain();
 						if(substr($serverName, 0, 4) == 'www.') $serverName = str_replace('www.', '', $serverName);
 						if(!strpos($serverName, 'localhost') && strpos($collArr['dwcaurl'], $serverName) === false) {
 							$baseUrl = substr($collArr['dwcaurl'], 0, strpos($collArr['dwcaurl'], '/content')) . '/collections/datasets/datapublisher.php';
@@ -390,7 +389,7 @@ if ($isEditor) {
 									?>
 									<div style="margin:10px 0px;clear:both;">
 										<?php
-										$collPath = GeneralUtil::getDomain() . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $collid;
+										$collPath = $collManager->getDomain() . $CLIENT_ROOT . '/collections/misc/collprofiles.php?collid=' . $collid;
 										$bodyStr = 'Please provide the following GBIF user permission to create and update datasets for the following GBIF publisher.<br/>' .
 											'Once these permissions are assigned, we will be pushing a DwC-Archive from the following Symbiota collection to GBIF.<br/><br/>' .
 											'GBIF user: ' . $GBIF_USERNAME . '<br/>' .

--- a/collections/datasets/dwcahandler.php
+++ b/collections/datasets/dwcahandler.php
@@ -2,7 +2,14 @@
 /*
  * Handler can be used to automate DwC-Archive publishing
  * PHP must be setup to run via command line. Automate by adding call to handler as a cron job, or scheduled task.
- * Variables in order: collids (required, multiple ids delimited by commas are allowed), serverDomain (required), includeIdentificationHistory (optional, 0 or 1, 1 = default), includeImages (optional, 0 or 1, 1 = default), includeAttributes (optional, 0 or 1, 1 = default), redactLocalities (optional, 0 or 1, 1 = default)
+ * Variables in order: 	collids (required, multiple ids delimited by commas are allowed),
+ * 						serverDomain (required),
+ * 						includeIdentificationHistory (optional, 0 or 1, 1 = default),
+ * 						includeImages (optional, 0 or 1, 1 = default),
+ * 						redactLocalities (optional, 0 or 1, 1 = default),
+ * 						includeAttributes (optional, 0 or 1, 1 = default),
+ * 						includeMatSample (optional, 0 or 1, 1 = default),
+ * 						includeIdentifiers (optional, 0 or 1, 1 = default),
  * ex: php dwcahandler.php 1 http://swbiodiversity.org 0 0 0 1
  * ex: php dwcahandler.php 160 http://nansh.org
  */
@@ -17,6 +24,7 @@ if($argc){
 	$includeImgs = 1;
 	$includeAttributes = 1;
 	$inlcudeMaterialSample = 1;
+	$includeIdentifiers = 1;
 	$redactLocalities = 1;
 	if($argc > 3 && is_numeric($argv[3])){
 		$includeDets = $argv[3];
@@ -28,6 +36,9 @@ if($argc){
 					$includeAttributes = $argv[6];
 					if($argc > 7 && is_numeric($argv[7])){
 						$inlcudeMaterialSample = $argv[7];
+						if($argc > 8 && is_numeric($argv[8])){
+							$includeIdentifiers = $argv[8];
+						}
 					}
 				}
 			}
@@ -40,6 +51,7 @@ if($argc){
 		$dwcaManager->setIncludeImgs($includeImgs);
 		$dwcaManager->setIncludeAttributes($includeAttributes);
 		if($dwcaManager->hasMaterialSamples()) $dwcaManager->setIncludeMaterialSample($inlcudeMaterialSample);
+		if($dwcaManager->hasIdentifiers()) $dwcaManager->setIncludeIdentifiers($includeIdentifiers);
 		$dwcaManager->setRedactLocalities($redactLocalities);
 		$dwcaManager->setServerDomain($serverDomain);
 		$dwcaManager->setTargetPath($SERVER_ROOT.(substr($SERVER_ROOT,-1)=='/'?'':'/').'content/dwca/');

--- a/collections/download/downloadhandler.php
+++ b/collections/download/downloadhandler.php
@@ -21,6 +21,7 @@ if ($schema == 'backup') {
 			$dwcaHandler->setIncludeImgs(1);
 			$dwcaHandler->setIncludeAttributes(1);
 			if ($dwcaHandler->hasMaterialSamples()) $dwcaHandler->setIncludeMaterialSample(1);
+			if ($dwcaHandler->hasIdentifiers()) $dwcaHandler->setIncludeIdentifiers(1);
 			$dwcaHandler->setRedactLocalities(0);
 			$dwcaHandler->setCollArr($collid);
 
@@ -122,6 +123,8 @@ if ($schema == 'backup') {
 			$dwcaHandler->setIncludeDets(0);
 			$dwcaHandler->setIncludeImgs(0);
 			$dwcaHandler->setIncludeAttributes(0);
+			$dwcaHandler->setIncludeMaterialSample(0);
+			$dwcaHandler->setIncludeIdentifiers(0);
 			$dwcaHandler->setOverrideConditionLimit(true);
 			$dwcaHandler->addCondition('catalognumber', 'NOT_NULL');
 			$dwcaHandler->addCondition('locality', 'NOT_NULL');
@@ -183,6 +186,8 @@ if ($schema == 'backup') {
 			$dwcaHandler->setIncludeAttributes($includeAttributes);
 			$includeMaterialSample = (array_key_exists('materialsample', $_POST) ? 1 : 0);
 			$dwcaHandler->setIncludeMaterialSample($includeMaterialSample);
+			$includeIdentifiers = (array_key_exists('identifiers', $_POST) ? 1 : 0);
+			$dwcaHandler->setIncludeIdentifiers($includeIdentifiers);
 
 			$outputFile = $dwcaHandler->createDwcArchive();
 		} else {

--- a/collections/download/index.php
+++ b/collections/download/index.php
@@ -83,7 +83,8 @@ $dwcManager = new DwcArchiverCore();
 	<style>
 		fieldset{ margin:10px; padding:10px }
 		legend{ font-weight:bold }
-		.sectionDiv{ clear:both; margin:20px; overflow:auto; }
+		button { display: inline; }
+		.sectionDiv{ clear:both; margin:20px; }
 		.labelDiv{ float:left; font-weight:bold; width:200px }
 		.formElemDiv{ float:left }
 	</style>
@@ -105,7 +106,7 @@ $dwcManager = new DwcArchiverCore();
 	<div style="width:100%; background-color:white;">
 		<h1 class="page-heading"><?php echo (isset($LANG['DATA_GUIDE']) ? $LANG['DATA_GUIDE'] : 'Data Usage Guidelines'); ?></h1>
 		<div style="margin:15px 0px;">
-		<?php echo (isset($LANG['GUIDE_ONE']) ? $LANG['GUIDE_ONE'] : 'By downloading data, the user confirms that he/she has read and agrees with the general'); ?> <a href="../../includes/usagepolicy.php#images"> <?php echo (isset($LANG['GUIDE_LINK']) ? $LANG['GUIDE_LINK'] : 'data usage terms'); ?> </a>.
+		<?php echo (isset($LANG['GUIDE_ONE']) ? $LANG['GUIDE_ONE'] : 'By downloading data, the user confirms that he/she has read and agrees with the general'); ?> <a href="../../includes/usagepolicy.php#images"> <?= $LANG['GUIDE_LINK'] ?> </a>.
 			<?php echo (isset($LANG['GUIDE_TWO']) ? $LANG['GUIDE_TWO'] : 'Note that additional terms of use specific to the individual collections may be distributed with the data download. When present, the terms
 			supplied by the owning institution should take precedence over the general terms posted on the website.'); ?>
 		</div>
@@ -157,8 +158,9 @@ $dwcManager = new DwcArchiverCore();
 								<label for="images"> <?php echo (isset($LANG['INCLUDE_IMG']) ? $LANG['INCLUDE_IMG'] : 'include Image Records'); ?> </label>
 								<br/>
 								<?php
-								if($dwcManager->hasAttributes()) echo '<input type="checkbox" name="attributes" id="attributes" value="1" onchange="extensionSelected(this)" checked /> <label for="attributes">' . (isset($LANG['INCLUDE_ATTR']) ? $LANG['INCLUDE_ATTR'] : 'include Occurrence Trait Attributes') . '</label><br/>';
-								if($dwcManager->hasMaterialSamples()) echo '<input type="checkbox" name="materialsample" id="materialsample" value="1" onchange="extensionSelected(this)" checked /><label for="materialsample">' . (isset($LANG['IMCLUDE_MAT']) ? $LANG['IMCLUDE_MAT'] : 'include Material Samples') . '</label><br/>';
+								if($dwcManager->hasAttributes()) echo '<input type="checkbox" name="attributes" id="attributes" value="1" onchange="extensionSelected(this)" checked /> <label for="attributes">' . $LANG['INCLUDE_ATTR'] . '</label><br/>';
+								if($dwcManager->hasMaterialSamples()) echo '<input type="checkbox" name="materialsample" id="materialsample" value="1" onchange="extensionSelected(this)" checked /><label for="materialsample">' . $LANG['IMCLUDE_MAT'] . '</label><br/>';
+								if($dwcManager->hasIdentifiers()) echo '<input type="checkbox" name="identifiers" id="identifiers" value="1" onchange="extensionSelected(this)" checked /> <label for="identifiers">' . $LANG['INCLUDE_IDENT'] . '</label><br/>';
 								?>
 								*<?php echo (isset($LANG['DATA_EXT_NOTE']) ? $LANG['DATA_EXT_NOTE'] : 'Output must be a compressed archive'); ?>
 							</div>
@@ -203,7 +205,7 @@ $dwcManager = new DwcArchiverCore();
 						<input name="taxonFilterCode" type="hidden" value="<?= $taxonFilterCode; ?>" />
 						<input name="sourcepage" type="hidden" value="<?= htmlspecialchars($sourcePage); ?>" />
 						<input name="searchvar" type="hidden" value="<?= $searchVar ?>" />
-						<button type="submit" name="submitaction"> <?= $LANG['DOWNLOAD_DATA'] ?></button>
+						<button type="submit" name="submitaction"><?= $LANG['DOWNLOAD_DATA'] ?></button>
 						<img id="workingcircle" src="../../images/ajax-loader_sm.gif" style="margin-bottom:-4px;width:20px;display:none;" />
 					</div>
 					<div class="sectionDiv">

--- a/collections/specprocessor/rpc/coge_build_dwca.php
+++ b/collections/specprocessor/rpc/coge_build_dwca.php
@@ -28,6 +28,7 @@ if($collid && is_numeric($collid)){
 		$dwcaHandler->setIncludeDets(0);
 		$dwcaHandler->setIncludeImgs(0);
 		$dwcaHandler->setIncludeAttributes(0);
+		$dwcaHandler->setIncludeIdentifiers(0);
 		$dwcaHandler->setOverrideConditionLimit(true);
 		$dwcaHandler->addCondition('catalognumber','NOT_NULL');
 		$dwcaHandler->addCondition('locality','NOT_NULL');

--- a/content/lang/collections/datasets/datapublisher.en.php
+++ b/content/lang/collections/datasets/datapublisher.en.php
@@ -23,11 +23,11 @@ $LANG['DWC'] = 'Darwin Core';
 $LANG['DWCA_EXPLAIN_3'] = ' exchange standard. We recommend that you also review instructions for';
 $LANG['PUBLISH_IDIGBIO'] = 'Publishing Occurrence Data to iDigBio';
 $LANG['PUBLISH_GBIF'] = 'Publishing Occurrence Data to GBIF';
-$LANG['DWCA_DOWNLOAD_EXPLAIN_1'] = 'The following downloads are occurrence data packages from collections being published as ';
-$LANG['DWCA_DOWNLOAD_EXPLAIN_2'] = 'files. DwC-A files are a single compressed ZIP file that contains one to several data files along with a meta.xml
-	document that describes the content and a CITEME.txt file that describes how to cite the portal. Archives published through this portal contain comma separated (CSV) files containing occurrences,
-	identifications (determinations), material samples, measurement or facts, and multimedia metadata. Fields within the occurrences.csv file are defined by the';
-$LANG['DWCA_DOWNLOAD_EXPLAIN_3'] = 'exchange standard. Other files follow the DwC extensions for those data types.';
+$LANG['DWCA_DOWNLOAD_EXPLAIN_1'] = 'The following downloads are occurrence data packages from collections that have chosen to publish their complete dataset as a';
+$LANG['DWCA_DOWNLOAD_EXPLAIN_2'] = 'file. DwC-A files are a single compressed ZIP file that contains one to several data files along with a meta.xml
+	document that describes the content. Archives published through this portal contain three comma separated (CSV) files containing occurrences,
+	identifications (determinations), and image metadata. Fields within the occurrences.csv file are defined by the';
+$LANG['DWCA_DOWNLOAD_EXPLAIN_3'] = 'exchange standard. The identification and image files follow the DwC extensions for those data types.';
 $LANG['DATA_USE_POLICY'] = 'Data Usage Policy';
 $LANG['DATA_POLICY_1'] = 'Use of these datasets requires agreement with the terms and conditions in our';
 $LANG['DATA_POLICY_2'] = 'Locality details for rare, threatened, or sensitive records have been redacted from these data files.
@@ -84,6 +84,7 @@ $LANG['INCLUDE_DETS'] = 'Include Determination History';
 $LANG['INCLUDE_IMGS'] = 'Include Image URLs';
 $LANG['INCLUDE_ATTRIBUTES'] = 'Include Occurrence Trait Attributes';
 $LANG['INCLUDE_MATSAMPLE'] = 'Include Material Sample';
+$LANG['INCLUDE_IDENTIFIERS'] = 'Include Alternative Identifiers';
 $LANG['REDACT_LOC'] = 'Redact Sensitive Localities';
 $LANG['CREATE_REFRESH'] = 'Create/Refresh Darwin Core Archive';
 $LANG['NOTE_LACKING_EXCLUDED'] = 'NOTE: all records lacking occurrenceID GUIDs will be excluded';

--- a/content/lang/collections/datasets/datapublisher.es.php
+++ b/content/lang/collections/datasets/datapublisher.es.php
@@ -84,6 +84,7 @@ $LANG['INCLUDE_DETS'] = 'Incluir Historia de Determinación';
 $LANG['INCLUDE_IMGS'] = 'Incluir URL de las Imágenes';
 $LANG['INCLUDE_ATTRIBUTES'] = 'Incluir atributos de rasgos de ocurrencia';
 $LANG['INCLUDE_MATSAMPLE'] = 'Incluir Material Sample';
+$LANG['INCLUDE_IDENTIFIERS'] = 'Incluir Identificadores Alternativos';
 $LANG['REDACT_LOC'] = 'Ocultar localidades sensibles';
 $LANG['CREATE_REFRESH'] = 'Crear/Refrescar Archivo Darwin Core';
 $LANG['NOTE_LACKING_EXCLUDED'] = 'NOTA: todos los registros que carezcan de occurrenceID GUIDs serán excluídos';

--- a/content/lang/collections/datasets/datapublisher.fr.php
+++ b/content/lang/collections/datasets/datapublisher.fr.php
@@ -84,6 +84,7 @@ $LANG['INCLUDE_DETS'] = 'Inclure Historique des Déterminations';
 $LANG['INCLUDE_IMGS'] = 'Inclure URLs des Images';
 $LANG['INCLUDE_ATTRIBUTES'] = 'Incluir atributos de rasgos de ocurrencia';
 $LANG['INCLUDE_MATSAMPLE'] = "Inclure les attributs des traits d'occurrence";
+$LANG['INCLUDE_IDENTIFIERS'] = 'Inclure les Identifiants Alternatifs';
 $LANG['REDACT_LOC'] = 'Supprimer Localités Sensibles';
 $LANG['CREATE_REFRESH'] = 'Créer/Actualiser Archive Darwin Core';
 $LANG['NOTE_LACKING_EXCLUDED'] = 'REMARQUE: tous les enregistrements dépourvus de GUID occurrenceID seront exclus';

--- a/content/lang/collections/download/index.en.php
+++ b/content/lang/collections/download/index.en.php
@@ -34,6 +34,7 @@ $LANG['INCLUDE_HISTORY'] = 'include Determination History';
 $LANG['INCLUDE_IMG'] = 'include Image Records';
 $LANG['INCLUDE_ATTR'] = 'include Occurrence Trait Attributes';
 $LANG['IMCLUDE_MAT'] = 'include Material Samples';
+$LANG['INCLUDE_IDENT'] = 'include Alternative Identifiers';
 $LANG['DATA_EXT_NOTE'] = 'Output must be a compressed archive';
 $LANG['FILE_FORMAT'] = 'File Format';
 $LANG['COMMA_DELIM'] = 'Comma Delimited (CSV)';

--- a/content/lang/collections/download/index.es.php
+++ b/content/lang/collections/download/index.es.php
@@ -34,6 +34,7 @@ $LANG['INCLUDE_HISTORY'] = 'incluir Historial de Determinación';
 $LANG['INCLUDE_IMG'] = 'incluir registros de imágenes';
 $LANG['INCLUDE_ATTR'] = 'incluir atributos de rasgo de ocurrencia';
 $LANG['IMCLUDE_MAT'] = 'incluir muestras de materiales';
+$LANG['INCLUDE_IDENT'] = 'incluir Identificadores Alternativos';
 $LANG['DATA_EXT_NOTE'] = 'La salida debe ser un archivo comprimido';
 $LANG['FILE_FORMAT'] = 'Formato de archivo';
 $LANG['COMMA_DELIM'] = 'Delimitado por comas (CSV)';

--- a/content/lang/collections/download/index.fr.php
+++ b/content/lang/collections/download/index.fr.php
@@ -11,6 +11,7 @@ $LANG['RETURN'] = 'Retour à la page de recherche';
 $LANG['OCC_DOWNLOAD'] = 'Téléchargement de l\'enregistrement d\'événement';
 $LANG['DATA_GUIDE'] = 'Consignes d\'utilisation des données';
 $LANG['GUIDE_ONE'] = 'En téléchargeant des données, l\'utilisateur confirme qu\'il a lu et accepte les conditions générales d\'utilisation des données';
+$LANG['GUIDE_LINK'] = "conditions d\'utilisation des données";
 $LANG['GUIDE_TWO'] = 'Notez que des conditions d\'utilisation supplémentaires spécifiques aux collections individuelles peuvent être distribuées avec le téléchargement des données. Lorsqu\'ils sont présents, les termes
                          fournies par l\'établissement propriétaire doivent prévaloir sur les conditions générales publiées sur le site Internet.';
 $LANG['DOWNLOAD_CHECKl'] = 'Télécharger la liste de contrôle';
@@ -33,6 +34,7 @@ $LANG['INCLUDE_HISTORY'] = 'inclure l\'historique des déterminations';
 $LANG['INCLUDE_IMG'] = 'inclure les enregistrements d\'images';
 $LANG['INCLUDE_ATTR'] = 'inclure les attributs de trait d\'occurrence';
 $LANG['IMCLUDE_MAT'] = 'inclure des échantillons de matériaux';
+$LANG['INCLUDE_IDENT'] = 'inclure Identifiants Alternatifs';
 $LANG['DATA_EXT_NOTE'] = 'La sortie doit être une archive compressée';
 $LANG['FILE_FORMAT'] = 'Format de fichier';
 $LANG['COMMA_DELIM'] = 'Délimité par des virgules (CSV)';

--- a/webservices/dwc/dwcapubhandler.php
+++ b/webservices/dwc/dwcapubhandler.php
@@ -19,6 +19,7 @@
  *   imgs (0, 1 [default]): Output image URLs within an media extension file
  *   dets (0, 1 [default]): Output determination history within an identification extension file
  *   attr (0 [default], 1): Output occurrence attribute values within a MeasurementOrFact extension file
+ *   ident (0 [default], 1): Output occurrence identifiers values within an Alternative Identifiers extension file
  *
  * Return: Darwin Core Archive of matching occurrences, associated images, identification history, and other associated data extensions
  *   Occurrence record return limited to 1,000,000 records
@@ -41,11 +42,12 @@ $collid = array_key_exists('collid', $_REQUEST) ? $_REQUEST['collid'] : 0;
 $cond = array_key_exists('cond', $_REQUEST) ? $_REQUEST['cond'] : '';
 $collType = array_key_exists('colltype', $_REQUEST) ? $_REQUEST['colltype'] : '';
 $schemaType = array_key_exists('schema', $_REQUEST) ? $_REQUEST['schema'] : 'dwc';
-$extended = array_key_exists('extended', $_REQUEST) ? $_REQUEST['extended'] : 0;
-$includeDets = array_key_exists('dets', $_REQUEST) ? $_REQUEST['dets'] : 1;
-$includeImgs = array_key_exists('imgs', $_REQUEST) ? $_REQUEST['imgs'] : 1;
-$includeAttributes = array_key_exists('attr', $_REQUEST) ? $_REQUEST['attr'] : 0;
-$includeMaterialSample = array_key_exists('matsample', $_REQUEST) ? $_REQUEST['matsample'] : 0;
+$extended = !empty($_REQUEST['extended']) ? 1 : 0;
+$includeDets = isset($_REQUEST['dets']) && !$_REQUEST['dets'] ? 0 : 1;
+$includeImgs = isset($_REQUEST['imgs']) && !$_REQUEST['imgs'] ? 0 : 1;
+$includeAttributes = !empty($_REQUEST['attr']) ? 1 : 0;
+$includeMaterialSample = !empty($_REQUEST['matsample']) ? 1 : 0;
+$includeIdentifiers = !empty($_REQUEST['ident']) ? 1 : 0;
 $pubGuid = array_key_exists('publicationguid', $_REQUEST) ? $_REQUEST['publicationguid'] : 0;
 $requestPortalGuid = array_key_exists('portalguid', $_REQUEST) ? $_REQUEST['portalguid'] : 0;
 
@@ -100,6 +102,7 @@ $dwcaHandler->setIncludeDets($includeDets);
 $dwcaHandler->setIncludeImgs($includeImgs);
 $dwcaHandler->setIncludeAttributes($includeAttributes);
 $dwcaHandler->setIncludeMaterialSample($includeMaterialSample);
+$dwcaHandler->setIncludeIdentifiers($includeIdentifiers);
 $dwcaHandler->setPublicationGuid($pubGuid);
 $dwcaHandler->setRequestPortalGuid($requestPortalGuid);
 


### PR DESCRIPTION
- Add Alternative Identifiers extension (https://rs.gbif.org/extension/gbif/1.0/identifier.xml) to the DwC-Archive export, which includes data backups
- Add support to public download handler
- Add support to DwC-A pub automation handler
- Add support to DwC-A pub webservice handler
- Exclude from CoGe data files
- Mics adjustment to sanitation and language terms
- Tested the DwC-A output file within the GBIF DwC-Archive validation tool: https://www.gbif.org/tools/data-validator

