### PR TITLE
email to personnel translation

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -2233,7 +2233,8 @@ class OccurrenceHarvester{
 		}
 		else{
 			//Look to see if string can be translated via NeonPersonnel table
-			$sql = 'SELECT full_info FROM NeonPersonnel WHERE neon_email = ? OR orcid = ?';
+			$sql = "SELECT full_info FROM NeonPersonnel 
+			WHERE SUBSTRING_INDEX(neon_email, '@', 1) = SUBSTRING_INDEX(?, '@', 1) OR orcid = ?";
 			if($stmt = $this->conn->prepare($sql)){
 				$stmt->bind_param('ss', $persStr, $persStr);
 				$stmt->execute();


### PR DESCRIPTION
Often a single person will be associated with multiple battelle emails (e.g. @neoninc.org, @battelleecology.org) but only one will have been provided to us for translation in the database.