### PR TITLE
default to version changes

### DIFF
--- a/collections/admin/specuploadmap.php
+++ b/collections/admin/specuploadmap.php
@@ -630,8 +630,13 @@ include($SERVER_ROOT.'/includes/header.php');
 							if($isLiveData){
 								?>
 								<div style="margin:10px 0px;">
+									<!-- Start NEON customization -->
+									<!--
 									<input name="versiondata" type="checkbox" value="1">
-									<?php echo (isset($LANG['VERSION_DATA_CHANGES'])?$LANG['VERSION_DATA_CHANGES']:'Version data changes'); ?>
+									-->
+									<input name="versiondata" type="checkbox" value="1" checked />
+									<!-- End NEON customization -->
+									<?php echo (isset($LANG['VERSION_DATA_CHANGES']) ? $LANG['VERSION_DATA_CHANGES'] : 'Version data changes'); ?>
 								</div>
 								<?php
 							}


### PR DESCRIPTION
preferred that this is the default since failing to version makes the harvester overwrite manually loaded values

For example, I forgot here #669 