### PR TITLE
Subsampling inverts

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -1114,7 +1114,6 @@ class OccurrenceHarvester{
 		$collArr[7] = array('targetCollid' => 108, 'lotId' => 'dynamic','defaultId' => 'Plantae');
 		$collArr[8] = array('targetCollid' => 109, 'lotId' => 'dynamic','defaultId' => 'Plantae');
 		$collArr[9] = array('targetCollid' => 107, 'lotId' => 'dynamic','defaultId' => 'Plantae');
-		//$collArr[22] = array('targetCollid' => 100, 'lotId' => 'dynamic','defaultId' => 'Chironomidae');
 		$collArr[22] = array('targetCollid' => 100, 'lotId' => 'dynamic','defaultId' => 'Chironomidae');
 		$collArr[45] = array('targetCollid' => 104, 'defaultId' => 'Zooplankton');
 		//$collArr[47] = array('targetCollid' => 110, 'lotId' => 'dynamic','defaultId' => 'ECO');

--- a/neon/search/index.php
+++ b/neon/search/index.php
@@ -471,5 +471,5 @@ $siteData = new DatasetsMetadata();
 	include($SERVER_ROOT . '/includes/footer.php');
 	?>
 </body>
-<script src="js/searchform.js?ver=09" type="text/javascript"></script>
+<script src="js/searchform.js?ver=10" type="text/javascript"></script>
 </html>

--- a/neon/search/js/searchform.js
+++ b/neon/search/js/searchform.js
@@ -940,9 +940,5 @@ hideColCheckbox(55);
 //Hides opal soils
 hideColCheckbox(96); 
 // Hides subsample collections for the moment
-hideColCheckbox(100);
-hideColCheckbox(101);
-hideColCheckbox(102);
-hideColCheckbox(103);
 hideColCheckbox(110);
 hideColCheckbox(111);


### PR DESCRIPTION
Many required changes and enhancements:

-allows for seperate records to be created for repeated scinames that differ in other important characteristics
-adds life stage to subsampler
- helps enforce taxonGroup relationships to prevent incorrect mappings
- sampleClass specific handling of inv_pervial_in vs. inv_per_taxon tables
- sampleClass specific handling due to lack of consistency in subsample identification date
- requirement to subset possible IDs based on parent taxa when all identifications associated with parent taxon (subsequently deal with issue in which no remaining records exist e.g. chironomid sample and parent sample associated with no chironomid identifications)
- adds delete subsamples for case when now zero subsamples exist
- fixes issue with choosing higher than necessary common parent when one subsample is the parent itself
-fixes minor bug with $identRemarks
