### PR TITLE
hide new large invert collection

### DIFF
--- a/neon/search/index.php
+++ b/neon/search/index.php
@@ -471,5 +471,5 @@ $siteData = new DatasetsMetadata();
 	include($SERVER_ROOT . '/includes/footer.php');
 	?>
 </body>
-<script src="js/searchform.js?ver=10" type="text/javascript"></script>
+<script src="js/searchform.js?ver=11" type="text/javascript"></script>
 </html>

--- a/neon/search/js/searchform.js
+++ b/neon/search/js/searchform.js
@@ -942,3 +942,5 @@ hideColCheckbox(96);
 // Hides subsample collections for the moment
 hideColCheckbox(110);
 hideColCheckbox(111);
+// Hides large invert collection for now
+hideColCheckbox(114);


### PR DESCRIPTION
Need to hide this new collection. Will be used once good det<->samp relationships exist for this sample class. Until then the sample class will be published to the mixed taxonomy subsample class.
