### PR TITLE
Update OccurrenceHarvester.php

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -474,7 +474,8 @@ class OccurrenceHarvester{
 				//if(strpos($tableName,'identification')) continue;
 				//if(strpos($tableName,'sorting')) continue;
 				if(strpos($tableName,'scs_archive')) continue;
-				//if(strpos($tableName,'barcoding')) continue;
+				if(strpos($tableName,'mam_barcoding')) continue;
+				if(strpos($tableName,'bet_barcoding')) continue;
 				if(strpos($tableName,'dnaStandardTaxon')) continue;
 				if(strpos($tableName,'dnaExtraction')) continue;
 				if(strpos($tableName,'markerGeneSequencing')) continue;


### PR DESCRIPTION
skip beetle and mammal barcoding tables but allow mos barcoding tables to persist. due to issues arising from identification history updates

step to addressing #727 
