### PR TITLE
adds association when cloning records

### DIFF
--- a/classes/OccurrenceEditorManager.php
+++ b/classes/OccurrenceEditorManager.php
@@ -1452,8 +1452,9 @@ class OccurrenceEditorManager {
 				if($sourceOccid != $this->occid && !in_array($this->occid,$retArr)){
 					$retArr[$this->occid] = $this->occid;
 					if(isset($postArr['assocrelation']) && $postArr['assocrelation']){
-						$sql = 'INSERT INTO omoccurassociations(occid, occidAssociate, relationship,createdUid) '.
-							'values('.$this->occid.','.$sourceOccid.',"'.$postArr['assocrelation'].'",'.$GLOBALS['SYMB_UID'].') ';
+						$sql = 'INSERT INTO omoccurassociations(occid, associationType, occidAssociate, relationship,createdUid) '.
+							'values('.$this->occid.', \'internalOccurrence\','.$sourceOccid.',"'.$postArr['assocrelation'].'",'.$GLOBALS['SYMB_UID'].') ';
+							
 						if(!$this->conn->query($sql)){
 							$this->errorArr[] = $LANG['ERROR_ADDING_REL'].': '.$this->conn->error;
 						}


### PR DESCRIPTION
I think a schema change might be preventing the addition of the association when records are cloned? I also don't know if it is symbiota-wide?

