### PR TITLE
get material sample ID in download

### DIFF
--- a/classes/DwcArchiverMaterialSample.php
+++ b/classes/DwcArchiverMaterialSample.php
@@ -22,7 +22,7 @@ class DwcArchiverMaterialSample extends DwcArchiverBaseManager{
 	private function setFieldArr(){
 		$columnArr['coreid'] = 'm.occid';
 		$termArr['materialSampleID'] = 'http://rs.tdwg.org/dwc/terms/materialSampleID';
-		$columnArr['materialSampleID'] = 'm.guid';
+		$columnArr['materialSampleID'] = 'm.matSampleID';
 		$termArr['sampleType'] = 'http://data.ggbn.org/schemas/ggbn/terms/materialSampleType';
 		$columnArr['sampleType'] = 'm.sampleType';
 		$termArr['catalogNumber'] = 'http://rs.tdwg.org/dwc/terms/catalogNumber';


### PR DESCRIPTION
This seems like it would solve #770 -  but maybe there is a reason it was like this before? Is the intention not that that field would be the primary key?  BTW - I did confirm that materialSampleID was also not populated in a download from Ecdysis. 