### PR TITLE
remove dataset warning

### DIFF
--- a/neon/classes/OccurrenceHarvester.php
+++ b/neon/classes/OccurrenceHarvester.php
@@ -2151,10 +2151,10 @@ class OccurrenceHarvester{
 				$datasetID = $row['datasetid'];
 			}
 
-			if (!$datasetID) {
-				$this->errorStr = 'ERROR: Dataset "'.$datasetName.'" not found.';
-				return;
-			}
+			// if (!$datasetID) {
+			// 	$this->errorStr = 'ERROR: Dataset "'.$datasetName.'" not found.';
+			// 	return;
+			// }
 
 			if ($datasetID <= 20){
 				// Delete existing entries for the given occid, if necessary


### PR DESCRIPTION
Dataset not found warning message now pops up whenever habitat values exist but are not nlcd classes. This will happen in a variety of cases causing an unnecessary warning. I'm electing to remove the warning altogether, as I don't know that it is particularly helpful in a site or domain not found scenario either.