### PR TITLE
Hotfix loan specimen check in bug

### DIFF
--- a/classes/OccurrenceLoans.php
+++ b/classes/OccurrenceLoans.php
@@ -706,103 +706,115 @@ class OccurrenceLoans extends Manager{
 		return $occArr;
 	}
 
-private function addLoanSpecimen($loanid, $occid) {
-    $status = false;
-    $sql1 = 'INSERT INTO omoccurloanslink(loanid, occid) VALUES ('. $loanid.','.$occid.')';
-    $sql2 = 'UPDATE omoccurrences SET availability = 0 WHERE occid ='.$occid;
-
-    $this->conn->begin_transaction();
-    if ($this->conn->query($sql1) && $this->conn->query($sql2)) {
-        // Both queries executed successfully, commit
-        $this->conn->commit();
-        $status = true;
-    } else {
-        // If any query fails, rollback
-        $this->conn->rollback();
-        $this->errorMessage = $this->conn->error;
-    }
-    return $status;
-}
+	private function addLoanSpecimen($loanid,$occid){
+		$status = false;
+		$sql = 'INSERT INTO omoccurloanslink(loanid,occid) VALUES (?,?) ';
+		if($stmt = $this->conn->prepare($sql)){
+			$stmt->bind_param('ii', $loanid, $occid);
+			try{
+				if($stmt->execute()){
+					$status = true;
+					$this->updateAvailability(0, $occid);		//This line is a NEON customization
+				}
+			} catch (mysqli_sql_exception $e){
+				$this->errorMessage = $stmt->error;
+			} catch (Exception $e){
+				$this->errorMessage = 'unknown error';
+			}
+			$stmt->close();
+		}
+		return $status;
+	}
 
 	public function getSpecimenDetails($loanId, $occid){
 		$retArr = array();
 		if(is_numeric($loanId) && is_numeric($occid)){
-			$sql = 'SELECT DATE_FORMAT(returndate, "%Y-%m-%dT%H:%i") AS returndate, notes FROM omoccurloanslink WHERE loanid = '.$loanId.' AND occid = '.$occid;
-			if($rs = $this->conn->query($sql)){
-				while($r = $rs->fetch_object()){
-					$retArr['returnDate'] = $r->returndate;
-					$retArr['notes'] = $r->notes;
+			$sql = 'SELECT returndate, notes FROM omoccurloanslink WHERE loanid = ? AND occid = ?';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('ii', $loanId, $occid);
+				$stmt->execute();
+				if($rs = $stmt->get_result()){
+					While($r = $rs->fetch_object()){
+						$retArr['returnDate'] = $r->returndate;
+						$retArr['notes'] = $r->notes;
+					}
+					$rs->free();
 				}
-				$rs->free();
+				$stmt->close();
 			}
 		}
 		return $retArr;
 	}
 
-public function editSpecimenDetails($loanId, $occid, $returnDate, $noteStr) {
-    $status = false;
-    if (is_numeric($loanId) && is_numeric($occid)) {
-        $sql1 = 'UPDATE omoccurloanslink '.
-            'SET returnDate = '.($returnDate?'"'.$this->cleanInStr($returnDate).'"':'NULL').', notes = '.($noteStr ? '"'.$this->cleanInStr($noteStr).'"':'NULL').' '.
-            'WHERE (loanid = '.$loanId.') AND (occid = '.$occid.')';
+	public function editSpecimenDetails($loanID, $occid, $returnDate, $noteStr){
+		$status = false;
+		if(is_numeric($loanID) && is_numeric($occid)){
+			if($returnDate === '') $returnDate = null;
+			$sql = 'UPDATE omoccurloanslink  SET returnDate = ?, notes = ?  WHERE (loanid = ?) AND (occid = ?)';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('ssii', $returnDate, $noteStr, $loanID, $occid);
+				try{
+					if($stmt->execute()){
+						$status = true;
+						if($returnDate) $this->updateAvailability(1, $occid);		//This line is a NEON customization
+					}
+				} catch (mysqli_sql_exception $e){
+					$this->errorMessage = $stmt->error;
+				} catch (Exception $e){
+					$this->errorMessage = 'unknown error';
+				}
+				$stmt->close();
+			}
+		}
+		return $status;
+	}
 
-        $this->conn->begin_transaction();
-
-        if ($this->conn->query($sql1)) {
-            if ($returnDate) {
-                $sql2 = 'UPDATE omoccurrences SET availability = 1 WHERE occid =' . $occid;
-                if ($this->conn->query($sql2)) {
-                    // Both queries executed successfully, commit
-                    $this->conn->commit();
-                    $status = true;
-                } else {
-                    // If the second sql fails, rollback
-                    $this->conn->rollback();
-                    $this->errorMessage = 'ERROR updating specimen availability: ' . $this->conn->error;
-                }
-            } else {
-                $this->conn->commit();
-                $status = true;
-            }
-        } else {
-            // If the first sql fails, rollback
-            $this->conn->rollback();
-            $this->errorMessage = 'ERROR updating specimen details: ' . $this->conn->error;
-        }
-    }
-    return $status;
-}
-
-	public function batchCheckinSpecimens($occidInput, $loanID) {
+	public function batchCheckinSpecimens($occidInput, $loanID){
 		$status = false;
 		$occidStr = '';
 		if(is_numeric($occidInput)) $occidStr = $occidInput;
 		else $occidStr = implode(',',$occidInput);
-		if (is_numeric($loanID) && preg_match('/^[\d,]+$/', $occidStr)) {
-			// Update returndate for specimens where loanid matches and returndate is null
-			$sql1 = 'UPDATE omoccurloanslink SET returndate = "'.date('Y-m-d H:i:s').'" WHERE loanid = '.$loanID.' AND (occid IN('.$occidStr.')) AND (returndate IS NULL) ';
-			
-			$this->conn->begin_transaction();
-			if ($this->conn->query($sql1)) {
-				$sql2 = 'UPDATE omoccurrences SET availability = 1 WHERE occid IN('.$occidStr.')';
-				if ($this->conn->query($sql2)) {
-					// Both sqls executed successfully, commit the transaction
-					$status = $this->conn->affected_rows;
-					$this->conn->commit();
-				} else {
-					// If the second sql fails, rollback
-					$this->conn->rollback();
-					$this->errorMessage = 'ERROR updating specimen availability: '.$this->conn->error;
+		if(is_numeric($loanID) && preg_match('/^[\d,]+$/', $occidStr)){
+			$sql = 'UPDATE omoccurloanslink SET returndate = "'.date('Y-m-d H:i:s').'" WHERE loanid = ? AND (occid IN('.$occidStr.')) AND (returndate IS NULL) ';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('i', $loanID);
+				try{
+					if($stmt->execute()){
+						$status = $this->conn->affected_rows;
+						$this->updateAvailability(1, $occidStr);		//This line is a NEON customization
+					}
+				} catch (mysqli_sql_exception $e){
+					$this->errorMessage = $stmt->error;
+				} catch (Exception $e){
+					$this->errorMessage = 'unknown error';
 				}
-			} else {
-				// If the sql query fails, rollback
-				$this->conn->rollback();
-				$this->errorMessage = 'ERROR checking in specimens: '.$this->conn->error;
+				$stmt->close();
 			}
 		}
-	
 		return $status;
 	}
+
+	//Start of NEON customization
+	private function updateAvailability($value, $occidInput){
+		$status = false;
+		//$occidInput might be an int (single occurrence) or a string of multiple occurrences
+		if(preg_match('/^[\d,]+$/', $occidInput)){
+			$sql = 'UPDATE omoccurrences SET availability = ? WHERE occid IN(' . $occidInput . ')';
+			if($stmt = $this->conn->prepare($sql)){
+				$stmt->bind_param('i', $value);
+				try{
+					if($stmt->execute()) $status = true;
+				} catch (mysqli_sql_exception $e){
+					$this->errorMessage = $stmt->error;
+				} catch (Exception $e){
+					$this->errorMessage = 'unknown error';
+				}
+				$stmt->close();
+			}
+		}
+		return $status;
+	}
+	//End of NEON customization
 
 	public function deleteSpecimens($occidArr, $loanID){
 		$status = false;

--- a/classes/OccurrenceLoans.php
+++ b/classes/OccurrenceLoans.php
@@ -756,7 +756,10 @@ class OccurrenceLoans extends Manager{
 				try{
 					if($stmt->execute()){
 						$status = true;
-						if($returnDate) $this->updateAvailability(1, $occid);		//This line is a NEON customization
+						//Start of NEON customization
+						if($returnDate) $this->updateAvailability(1, $occid);
+						else $this->updateAvailability(0, $occid);
+						//End of NEON customization
 					}
 				} catch (mysqli_sql_exception $e){
 					$this->errorMessage = $stmt->error;

--- a/collections/loans/specimentab.php
+++ b/collections/loans/specimentab.php
@@ -213,7 +213,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 	function displayNewDetPanel(mode){
 		if(mode){
 			hideAll();
-			$(".form-checkbox").show();
+			$(".form-checkbox").css("display", "revert");
 			$('#newdet-div').show();
 		}
 		else{
@@ -225,7 +225,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 	function displayBatchActionPanel(mode){
 		if(mode){
 			hideAll();
-			$(".form-checkbox").show();
+			$(".form-checkbox").css("display", "revert");
 			$("#batchaction-div").show();
 		}
 		else{
@@ -249,6 +249,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 	.form-checkbox{ display:none; }
 	label{ font-weight: bold }
 	.field-div{ margin: 10px 0px }
+	.icon-img{ width: 13px; }
 </style>
 <div id="outloanspecdiv">
 	<div id="menu-div">
@@ -322,7 +323,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 					<button name="formsubmit" type="submit"><?php echo $LANG['PROCESS_SPEC']; ?></button>
 				</div>
 			</form>
-			<form name="refreshspeclist" action="outgoing.php" method="post" style="float:left; margin-left:10px;">
+			<form name="refreshspeclist" action="outgoing.php" method="post" style="float:left; margin:8px;">
 				<input name="loanid" type="hidden" value="<?php echo $loanId; ?>" />
 				<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
 				<input name="tabindex" type="hidden" value="1" />
@@ -432,10 +433,10 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 						</td>
 						<td>
 							<div>
-								<a href="#" onclick="openIndPopup(<?php echo $occid; ?>); return false;"><img src="../../images/list.png" style="width:1.3em" title="<?php echo $LANG['OPEN_SPECIMEN_DETAILS']; ?>" /></a><br/>
+								<a href="#" onclick="openIndPopup(<?php echo $occid; ?>); return false;"><img class="icon-img" src="../../images/list.png" title="<?php echo $LANG['OPEN_SPECIMEN_DETAILS']; ?>" /></a><br/>
 							</div>
 							<div>
-								<a href="#" onclick="openEditorPopup(<?php echo $occid; ?>); return false;"><img src="../../images/edit.png" style="width:1.3em" title="<?php echo $LANG['OPEN_OCC_EDITOR']; ?>" /></a>
+								<a href="#" onclick="openEditorPopup(<?php echo $occid; ?>); return false;"><img class="icon-img" src="../../images/edit.png" title="<?php echo $LANG['OPEN_OCC_EDITOR']; ?>" /></a>
 							</div>
 						</td>
 						<td>
@@ -456,7 +457,7 @@ $specList = $loanManager->getSpecimenList($loanId, $sortTag);
 							?>
 						</td>
 						<td><?php
-						echo '<div style="float:right"><a href="#" onclick="openCheckinPopup(' . $loanId . ',' . $occid . ',' . $collid . ');return false"><img src="../../images/edit.png" style="width:13px" title="' . $LANG['EDIT_NOTES'] . '" /></a></div>';
+						echo '<div style="float:right"><a href="#" onclick="openCheckinPopup(' . $loanId . ',' . $occid . ',' . $collid . ');return false"><img class="icon-img" src="../../images/edit.png" title="' . $LANG['EDIT_NOTES'] . '" /></a></div>';
 						echo $specArr['returndate'];
 						?></td>
 					</tr>

--- a/collections/loans/specnoteseditor.php
+++ b/collections/loans/specnoteseditor.php
@@ -1,43 +1,45 @@
 <?php
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceLoans.php');
-if($LANG_TAG != 'en' && file_exists($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.' . $LANG_TAG . '.php');
-else include_once($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.en.php');
-header("Content-Type: text/html; charset=".$CHARSET);
-if(!$SYMB_UID) header('Location: ' . $CLIENT_ROOT . '/profile/index.php?refurl=../collections/loans/specimennotes.php?' . htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
+if($LANG_TAG != 'en' && file_exists($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.' . $LANG_TAG . '.php'))
+	include_once($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.' . $LANG_TAG . '.php');
+	else include_once($SERVER_ROOT . '/content/lang/collections/loans/loan_langs.en.php');
+	header("Content-Type: text/html; charset=".$CHARSET);
+	if(!$SYMB_UID) header('Location: ' . $CLIENT_ROOT . '/profile/index.php?refurl=../collections/loans/specimennotes.php?' . htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
 
-$collid = $_REQUEST['collid'];
-$occid = $_REQUEST['occid'];
-$loanID = $_REQUEST['loanid'];
+	$collid = filter_var($_REQUEST['collid'], FILTER_SANITIZE_NUMBER_INT);
+	$occid = filter_var($_REQUEST['occid'], FILTER_SANITIZE_NUMBER_INT);;
+	$loanID = filter_var($_REQUEST['loanid'], FILTER_SANITIZE_NUMBER_INT);;
 
-//Sanitation
-if(!is_numeric($collid)) $collid = 0;
-if(!is_numeric($occid)) $occid = 0;
-if(!is_numeric($loanID)) $loanID = 0;
-
-$isEditor = 0;
-if($SYMB_UID && $collid){
-	if($IS_ADMIN || (array_key_exists('CollAdmin',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollAdmin']))
-		|| (array_key_exists('CollEditor',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollEditor']))){
-		$isEditor = 1;
+	$isEditor = 0;
+	if($SYMB_UID && $collid){
+		if($IS_ADMIN || (array_key_exists('CollAdmin',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollAdmin']))
+				|| (array_key_exists('CollEditor',$USER_RIGHTS) && in_array($collid,$USER_RIGHTS['CollEditor']))){
+					$isEditor = 1;
+		}
 	}
-}
 
-$loanManager = new OccurrenceLoans();
-$loanManager->setCollId($collid);
-?>
+	$loanManager = new OccurrenceLoans();
+	$loanManager->setCollId($collid);
+	?>
 <!DOCTYPE html>
-<html lang="<?php echo $LANG_TAG ?>">
+<html lang="<?= $LANG_TAG ?>">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET;?>">
-	<title><?php echo $DEFAULT_TITLE . ' ' . $LANG['LOAN_NOTES_EDITOR']; ?></title>
-	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
+    <meta http-equiv="Content-Type" content="text/html; charset=<?= $CHARSET;?>">
+	<title><?= $DEFAULT_TITLE . ' ' . $LANG['LOAN_NOTES_EDITOR']; ?></title>
+	<link href="<?= $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
 	<?php
 	include_once($SERVER_ROOT . '/includes/head.php');
 	?>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
-	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
+	<script src="<?= $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
 	<script type="text/javascript">
+		function resetCheckin(f){
+			f.returndate.value = '';
+			f.notes.value = '';
+			f.formsubmit.click()
+		}
+
 		function submitNotesForm(f){
 			self.close();
 		}
@@ -46,33 +48,44 @@ $loanManager->setCollId($collid);
 		body{ width:800px; min-width:400px; max-width:1000px; background-color: #FFFFFF; }
 		fieldset{ padding:20px }
 		fieldset legend{ font-weight:bold }
+		button{ margin: 10px; display: inline; }
 	</style>
 </head>
 <body>
 	<!-- This is inner text! -->
 	<div id="popup-innertext" class="left-breathing-room-rel">
-		<h1 class="page-heading"><?= $LANG['LOAN_NOTES_EDITOR']; ?></h1>
+		<h1 class="page-heading screen-reader-only"><?= $LANG['LOAN_NOTES_EDITOR']; ?></h1>
 		<?php
 		if($isEditor && $collid){
-			$noteArr = $loanManager->getSpecimenDetails($loanID, $occid)
+			$noteArr = $loanManager->getSpecimenDetails($loanID, $occid);
 			?>
-				<form name="noteEditor" action="outgoing.php" method="post" target="parentWin" onsubmit="submitNotesForm()">
+			<form name="noteEditor" action="outgoing.php" method="post" target="parentWin" onsubmit="submitNotesForm()">
+				<fieldset>
+					<legend><?= $LANG['SPECIMEN_CHECKIN'] ?></legend>
 					<div>
-						<b><?php echo $LANG['DATE_RETURNED']; ?>:</b>
-						<input name="returndate" type="datetime-local" value="<?php echo $noteArr['returnDate']; ?>" />
+						<b><?= $LANG['DATE_RETURNED']; ?>:</b>
+						<input name="returndate" type="date" value="<?= $noteArr['returnDate'] ?>" />
 					</div>
 					<div>
-						<b><?php echo $LANG['SPEC_NOTES']; ?>:</b>
-						<input name="notes" type="text" value="<?php echo $noteArr['notes']; ?>" style="width:100%" />
+						<b><?= $LANG['SPEC_NOTES']; ?>:</b>
+						<input name="notes" type="text" value="<?= $noteArr['notes'] ?>" style="width:100%" />
 					</div>
 					<div>
-						<input name="loanid" type="hidden" value="<?php echo $loanID; ?>" />
-						<input name="occid" type="hidden" value="<?php echo $occid; ?>" />
-						<input name="collid" type="hidden" value="<?php echo $collid; ?>" />
+						<input name="loanid" type="hidden" value="<?= $loanID ?>" />
+						<input name="occid" type="hidden" value="<?= $occid ?>" />
+						<input name="collid" type="hidden" value="<?= $collid ?>" />
 						<input name="tabindex" type="hidden" value="1" />
-						<button name="formsubmit" type="submit" value="saveSpecimenDetails"><?php echo $LANG['SAVE_EDITS']; ?></button>
+						<button name="formsubmit" type="submit" value="saveSpecimenDetails"><?= $LANG['SAVE_EDITS']; ?></button>
+						<?php
+						if($noteArr['returnDate']){
+							?>
+							<button name="formreset" type="button" value="saveSpecimenDetails" onclick="resetCheckin(this.form)"><?= $LANG['RESET_CHECKIN']; ?></button>
+							<?php
+						}
+						?>
 					</div>
-				</form>
+				</fieldset>
+			</form>
 			<?php
 		}
 		else{

--- a/content/lang/collections/loans/loan_langs.en.php
+++ b/content/lang/collections/loans/loan_langs.en.php
@@ -219,9 +219,10 @@ $LANG['NO_SPECS_REGISTERED'] = 'There are no specimens registered for this loan.
 
 // from specnoteseditor.php
 $LANG['LOAN_NOTES_EDITOR'] = 'Loan Specimen Notes Editor';
+$LANG['SPECIMEN_CHECKIN'] = 'Specimen Check-in Editor';
 $LANG['LOAN_SPEC_EDIT'] = 'Loan Specimen Editor';
 $LANG['SPEC_NOTES'] = 'Specimen Notes';
 $LANG['SAVE_EDITS'] = 'Save Edits';
-
+$LANG['RESET_CHECKIN'] = 'Reset Check-in';
 
 ?>

--- a/content/lang/collections/loans/loan_langs.es.php
+++ b/content/lang/collections/loans/loan_langs.es.php
@@ -219,9 +219,10 @@ $LANG['NO_SPECS_REGISTERED'] = 'No hay especímenes registrados para este prést
 
 // from specnoteseditor.php
 $LANG['LOAN_NOTES_EDITOR'] = 'Editor de Notas de Préstamo de Especímenes';
+$LANG['SPECIMEN_CHECKIN'] = 'Editor de registro de muestras';
 $LANG['LOAN_SPEC_EDIT'] = 'Editor de Préstamo de Especímenes';
 $LANG['SPEC_NOTES'] = 'Notas de los Especímenes';
 $LANG['SAVE_EDITS'] = 'Guardar Ediciones';
-
+$LANG['RESET_CHECKIN'] = 'Restablecer registro';
 
 ?>

--- a/content/lang/collections/loans/loan_langs.fr.php
+++ b/content/lang/collections/loans/loan_langs.fr.php
@@ -224,9 +224,10 @@ $LANG['NO_SPECS_REGISTERED'] = 'Aucun spécimen n\'est enregistré pour ce prêt
 
 // from specnoteseditor.php
 $LANG['LOAN_NOTES_EDITOR'] = 'Éditeur de notes de spécimen de prêt';
+$LANG['SPECIMEN_CHECKIN'] = "Éditeur d'enregistrement de spécimens";
 $LANG['LOAN_SPEC_EDIT'] = 'Éditeur de spécimens de prêt';
 $LANG['SPEC_NOTES'] = 'Notes sur les spécimens';
 $LANG['SAVE_EDITS'] = 'Enregistrer les modifications';
-
+$LANG['RESET_CHECKIN'] = "Réinitialiser l'enregistrement";
 
 ?>

--- a/css/main.css
+++ b/css/main.css
@@ -130,10 +130,6 @@ body {
 
 /******* 2. LAYOUT ********/
 
-#innertext img {
-  max-width: 100%;
-}
-
 #middlecenter {
   padding: 0px;
 }

--- a/includes/head.php
+++ b/includes/head.php
@@ -1,5 +1,5 @@
 <?php
-$CSS_VERSION = '2';
+$CSS_VERSION = '3';
 ?>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!-- UNIVERSAL CSS –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
- Add try/catch to avoid FATAL errors when linking a specimen that is already linked, as well as other function associated with specimen check-in
- Isolate NEON customization in a separate function
- Parameterize SQL statements associated with loan check-in
- Add button to reset check-in of a specimen
- Sanitation improvements
- Mics styling adjustments and fixes