### PR TITLE
print id fields, remove taxonremarks editing

### DIFF
--- a/collections/editor/batchdeterminations.php
+++ b/collections/editor/batchdeterminations.php
@@ -521,17 +521,19 @@ if($isEditor){
 									<input type="text" name="dateidentified" id="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['ID_REFERENCE']; ?>:</b>
+									<b><?php echo $LANG['ID_REFERENCES']; ?>:</b>
 									<input type="text" name="identificationreferences" style="width:350px;" />
 								</div>
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['ID_REMARKS']; ?>:</b>
 									<input type="text" name="identificationremarks" style="width:350px;" />
 								</div>
+								<!-- START NEON Customization
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['TAXON_REMARKS']; ?>:</b>
 									<input type="text" name="taxonremarks" style="width:350px;" />
 								</div>
+								END NEON Customization -->
 								<div id="makeCurrentDiv" style='margin:3px;'>
 									<input type="checkbox" name="makecurrent" value="1" checked /> <?php echo $LANG['MAKE_CURRENT']; ?>
 								</div>

--- a/collections/editor/includes/determinationtab.php
+++ b/collections/editor/includes/determinationtab.php
@@ -188,7 +188,7 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 							<input type="text" name="dateidentified" style="background-color:lightyellow;" onchange="detDateChanged(this.form);" />
 						</div>
 						<div style='margin:3px;'>
-							<b><?php echo $LANG['ID_REFERENCE']; ?>:</b>
+							<b><?php echo $LANG['ID_REFERENCES']; ?>:</b>
 							<input type="text" name="identificationreferences" style="width:350px;" />
 						</div>
 						<div style='margin:3px;'>
@@ -261,7 +261,7 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 					if($detRec['identificationreferences']){
 						?>
 						<div style='margin:3px 0px 0px 15px;'>
-							<b><?php echo $LANG['ID_REFERENCE']; ?>:</b> <?php echo $detRec['identificationreferences']; ?>
+							<b><?php echo $LANG['ID_REFERENCES']; ?>:</b> <?php echo $detRec['identificationreferences']; ?>
 						</div>
 						<?php
 					}
@@ -321,17 +321,19 @@ $specImgArr = $occManager->getImageMap();  // find out if there are images in or
 									<input type="text" name="dateidentified" value="<?php echo $detRec['dateidentified']; ?>" style="background-color:lightyellow;" />
 								</div>
 								<div style='margin:3px;'>
-									<b><?php echo $LANG['ID_REFERENCE']; ?>:</b>
+									<b><?php echo $LANG['ID_REFERENCES']; ?>:</b>
 									<input type="text" name="identificationreferences" value="<?php echo $detRec['identificationreferences']; ?>" style="width:350px;" />
 								</div>
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['ID_REMARKS']; ?>:</b>
 									<input type="text" name="identificationremarks" value="<?php echo $detRec['identificationremarks']; ?>" style="width:350px;" />
 								</div>
+								<!-- START NEON Customization
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['TAXON_REMARKS']; ?>:</b>
 									<input type="text" name="taxonremarks" value="<?php echo $detRec['taxonremarks']; ?>" style="width:350px;" />
 								</div>
+								END NEON customization -->
 								<div style='margin:3px;'>
 									<b><?php echo $LANG['SORT_SEQUENCE']; ?>:</b>
 									<input type="text" name="sortsequence" value="<?php echo $detRec['sortsequence']; ?>" style="width:40px;" />

--- a/collections/editor/occurrenceeditor.php
+++ b/collections/editor/occurrenceeditor.php
@@ -1038,11 +1038,13 @@ else{
 												<a href="#" onclick="return dwcDoc('identification-remarks')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 												<input type="text" name="identificationremarks" value="<?php echo array_key_exists('identificationremarks',$occArr)?$occArr['identificationremarks']:''; ?>" onchange="fieldChanged('identificationremarks');" />
 											</div>
+											<!-- START NEON CUSTOMIZATION
 											<div id="taxonRemarksDiv" class="field-div">
 												<?php echo $LANG['TAXON_REMARKS']; ?>:
 												<a href="#" onclick="return dwcDoc('taxon-remarks')" tabindex="-1"><img class="docimg" src="../../images/qmark.png" /></a>
 												<input type="text" name="taxonremarks" value="<?php echo array_key_exists('taxonremarks',$occArr)?$occArr['taxonremarks']:''; ?>" onchange="fieldChanged('taxonremarks');" />
 											</div>
+											END NEON CUSTOMIZATION -->
 										</div>
 									</fieldset>
 									<fieldset>

--- a/content/lang/collections/editor/batchdeterminations.en.php
+++ b/content/lang/collections/editor/batchdeterminations.en.php
@@ -50,4 +50,9 @@ $LANG['ADD_DETERS'] = 'Add New Determinations';
 $LANG['NO_PERMISSIONS'] = 'You do not have permissions to set batch determinations for this collection.
 						Please contact the site administrator to obtain the necessary permissions.';
 
+// START NEON Customization
+$LANG['ID_REFERENCES'] = 'Identification Reference';
+$LANG['ID_REMARKS'] = 'Identification Remarks';
+// END NEON customization
+
 ?>

--- a/content/lang/collections/editor/includes/determinationtab.en.php
+++ b/content/lang/collections/editor/includes/determinationtab.en.php
@@ -47,4 +47,9 @@ $LANG['MAKE_CURRENT'] = 'Make Current';
 $LANG['SURE_DELETE'] = 'Are you sure you want to delete this specimen determination?';
 $LANG['DELETE_DET'] = 'Delete Determination';
 
+// START NEON Customization
+$LANG['ID_REFERENCES'] = 'Identification Reference';
+$LANG['ID_REMARKS'] = 'Identification Remarks';
+// END NEON customization
+
 ?>


### PR DESCRIPTION
(became somewhat high priority)

-prints id reference and id remarks field names ** looks like "reference" and "notes" used in seinet, feel free to change to that if preferred that we are consistent
-removes taxon remarks from editor of individual records/determinations

would solve #914 and #885 