### PR TITLE
Customized Neon occurrence/extended data editing/importing tool

### DIFF
--- a/classes/utilities/OccurrenceUtil.php
+++ b/classes/utilities/OccurrenceUtil.php
@@ -382,7 +382,9 @@ class OccurrenceUtil {
 	public static function occurrenceArrayCleaning($recMap){
 		//Trim all field values
 		foreach($recMap as $k => $v){
-			$recMap[$k] = trim($v);
+			//START NEON CUSTOMIZATION
+			if ($v != null) $recMap[$k] = trim($v);
+			//END NEON CUSTOMIZATION
 		}
 		//Date cleaning
 		if(isset($recMap['recordsecurity']) && !is_numeric($recMap['recordsecurity'])){

--- a/neon/classes/NeonEditor.php
+++ b/neon/classes/NeonEditor.php
@@ -15,7 +15,6 @@ class NeonEditor extends UtilitiesFileImport {
 	private $importType;
 	private $createNewRecord = false;
 
-
 	private $importManager = null;
 
     private const IMPORT_ASSOCIATIONS = 1;
@@ -283,6 +282,7 @@ class NeonEditor extends UtilitiesFileImport {
 					}
 				}
 				if (empty($identifierArr['occid'])) {
+                
 					$this->logOrEcho('ERROR loading identifier: occid could not be fetched from provided occurrence identifiers.', 1);
 					continue;
 				}
@@ -323,33 +323,33 @@ class NeonEditor extends UtilitiesFileImport {
 			}
 		}
         elseif ($this->importType == self::UPDATE_OCCURRENCE) {
-			$importManager = new OmoccurrenceEditor($this->conn);
-			foreach ($occidArr as $occid) {
-				$importManager->setOccid($occid);
-				$fieldArr = array_keys($importManager->getSchemaMap());
-                $occurrenceArr = array();
-				foreach ($fieldArr as $field) {
-					$fieldLower = strtolower($field);
-					if ($fieldLower == 'id') {
-						$occurrenceArr[$field] = $occid;
-					} else {
-						if (isset($this->fieldMap[$fieldLower])) $occurrenceArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
-					}
-				}
-				if (empty($occurrenceArr['id'])) {
-					$this->logOrEcho('ERROR: occid could not be fetched from provided occurrence identifiers.', 1);
-					continue;
-				}
-				if ($occurrenceArr['id']) {
-						$importManager->setOccurrenceID($occurrenceArr['id']);
-							$status = $importManager->updateOccurrence($occurrenceArr);
-						    $this->logOrEcho('Occurrence Updated' . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
-					if (!$status) {
-							$this->logOrEcho('ERROR updating occurrence. ' . $importManager->getErrorMessage(), 1);
-					}
-				}
-			}
-		}
+            $importManager = new OmoccurrenceEditor($this->conn);
+            foreach ($occidArr as $occid) {
+                $importManager->setOccid($occid);
+                $occurArr = $importManager->getOccurArr($occid);
+                if (empty($occurArr) || empty($occurArr['occid'])) {
+                    $this->logOrEcho('ERROR: occid could not be fetched from provided occurrence identifiers.', 1);
+                    continue;
+                }
+                $inputArr = [];
+                $fieldArr = array_keys($importManager->getSchemaMap());
+                foreach ($fieldArr as $field) {
+                    $fieldLower = strtolower($field);
+                    if (isset($this->fieldMap[$fieldLower])) {
+                        $srcIndex = $this->fieldMap[$fieldLower];
+                        $inputArr[$field] = isset($recordArr[$srcIndex]) ? $this->encodeString($recordArr[$srcIndex]) : null;
+                    }
+                }
+                $inputArr['occid'] = $occid;
+                $status = $importManager->updateOccurrence($inputArr,$occurArr,$postArr);
+                if ($status){
+                    $this->logOrEcho('Occurrence Updated' . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+                }
+                if (!$status) {
+                    $this->logOrEcho('ERROR updating occurrence <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid .'" target="_blank">' . $occid . '</a>'. $importManager->getErrorMessage(), 1);
+                }
+            }
+        }
 		return $status;
 	}
 
@@ -382,10 +382,22 @@ class NeonEditor extends UtilitiesFileImport {
 			}
 			$rs->free();
 		}
-		if (!$retArr) {
-            $this->logOrEcho('SKIPPED: Unable to find record matching any provided identifier(s): ' . implode(', ', $identifierArr), 1);
-		}
+        if ($retArr) {
+            if (count($retArr) > 1) {
+                $this->logOrEcho(
+                    'ERROR: Identifier matches multiple occurrence records: ' . implode(', ', $retArr),
+                    1
+                );
+                $retArr = array();
 
+            }
+        }
+        else {
+            $this->logOrEcho(
+                'SKIPPED: Unable to find record matching any provided identifier(s): ' . implode(', ', $identifierArr),
+                1
+            );
+        }
 		return $retArr;
 	}
 
@@ -501,8 +513,7 @@ class NeonEditor extends UtilitiesFileImport {
 				$this->translationMap = array();
 			} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
 				$this->translationMap = array();
-			}
-            elseif ($this->importType == self::UPDATE_OCCURRENCE) {
+			} elseif ($this->importType == self::UPDATE_OCCURRENCE) {
 				$this->translationMap = array();
 			}
 		}

--- a/neon/classes/NeonEditor.php
+++ b/neon/classes/NeonEditor.php
@@ -1,0 +1,546 @@
+<?php
+include_once('UtilitiesFileImport.php');
+include_once('ImageShared.php');
+include_once('OmMaterialSample.php');
+include_once('OmAssociations.php');
+include_once('OmDeterminations.php');
+include_once('OmIdentifiers.php');
+include_once('OmOccurrenceEditor.php');
+include_once('OccurrenceMaintenance.php');
+include_once('Media.php');
+include_once('utilities/UuidFactory.php');
+
+class NeonEditor extends UtilitiesFileImport {
+
+	private $importType;
+	private $createNewRecord = false;
+
+
+	private $importManager = null;
+
+    private const IMPORT_ASSOCIATIONS = 1;
+	private const IMPORT_DETERMINATIONS = 2;
+	private const IMPORT_IMAGE_MAP = 3;
+	private const IMPORT_MATERIAL_SAMPLE = 4;
+	private const IMPORT_IDENTIFIERS = 5;
+    private const UPDATE_OCCURRENCE = 6;
+
+	function __construct() {
+		parent::__construct(null, 'write');
+		$this->setVerboseMode(2);
+		set_time_limit(2000);
+	}
+
+	function __destruct() {
+		parent::__destruct();
+	}
+
+	public function loadData($postArr) {
+		global $LANG;
+		$status = false;
+		if ($this->fileName && isset($postArr['tf'])) {
+			$this->fieldMap = array_flip($postArr['tf']);
+			if ($this->setTargetPath()) {
+				if ($this->getHeaderArr()) {		// Advance past header row, set file handler, and define delimiter
+					$cnt = 1;
+					while ($recordArr = $this->getRecordArr()) {
+						$identifierArr = array();
+						if (isset($this->fieldMap['occid'])) {
+							if ($recordArr[$this->fieldMap['occid']]) $identifierArr['occid'] = $recordArr[$this->fieldMap['occid']];
+						}
+						if (isset($this->fieldMap['occurrenceid'])) {
+							if ($recordArr[$this->fieldMap['occurrenceid']]) $identifierArr['occurrenceID'] = $recordArr[$this->fieldMap['occurrenceid']];
+						}
+						if (isset($this->fieldMap['catalognumber'])) {
+							if ($recordArr[$this->fieldMap['catalognumber']]) $identifierArr['catalogNumber'] = $recordArr[$this->fieldMap['catalognumber']];
+						}
+						if (isset($this->fieldMap['othercatalognumbers'])) {
+							if ($recordArr[$this->fieldMap['othercatalognumbers']]) $identifierArr['otherCatalogNumbers'] = $recordArr[$this->fieldMap['othercatalognumbers']];
+						}
+						$this->logOrEcho('#' . $cnt . ': ' . $LANG['PROCESSING_CATNUM'] . ': ' . implode(', ', $identifierArr));
+						if ($occidArr = $this->getOccurrencePK($identifierArr)) {
+							$status = $this->insertRecord($recordArr, $occidArr, $postArr);
+						}
+						$cnt++;
+					}
+					$occurMain = new OccurrenceMaintenance($this->conn);
+					$this->logOrEcho($LANG['UPDATING_STATS'] . '...');
+				}
+				$this->deleteImportFile();
+			}
+		}
+		return $status;
+	}
+
+	private function insertRecord($recordArr, $occidArr, $postArr) {
+		global $LANG;
+		$status = false;
+		if ($this->importType == self::IMPORT_IMAGE_MAP) {
+			$importManager = new ImageShared($this->conn);
+
+			/* originalurl is a required field */
+			if (!isset($this->fieldMap['originalurl']) || !$recordArr[$this->fieldMap['originalurl']]) {
+				//$this->errorMessage = 'large url (originalUrl) is null (required)';
+				$this->logOrEcho('ERROR `originalUrl` field mapping is required', 1);
+				return false;
+			}
+
+			/* Media uploads must only be of one type */
+			if (!isset($postArr['mediaUploadType']) || !$postArr['mediaUploadType']) {
+				$this->logOrEcho('ERROR `mediaUploadType` is required', 1);
+				return false;
+			}
+
+			$fields = [
+				 //'tid',
+				'thumbnailUrl',
+				'url',
+				'sourceUrl',
+				'archiveUrl',
+				'referenceUrl',
+				'creator',
+				'creatoruid',
+				'caption',
+				'owner',
+				'anatomy',
+				'notes',
+				'format',
+				'sourceIdentifier',
+				'hashFunction',
+				'hashValue',
+				'mediaMD5',
+				'copyright',
+				'accessRights',
+				'rights',
+				'sortOccurrence'
+			];
+
+			foreach ($occidArr as $occid) {
+				$data = [
+					"occid" => $occid,
+					"originalUrl" => $recordArr[$this->fieldMap['originalurl']],
+					"mediaUploadType" => $postArr['mediaUploadType']
+				];
+				foreach($fields as $key) {
+					$record_idx = $this->fieldMap[$key] ?? $this->fieldMap[strtolower($key)] ?? false;
+					if($record_idx && $recordArr[$record_idx]) {
+						$data[$key] = $this->encodeString($recordArr[$record_idx]);
+					}
+				}
+
+				if (!isset($data['originalUrl']) && !$data['originalUrl']) {
+					$this->logOrEcho('SKIPPING Record ' . $occid . ' missing `originalUrl` value');
+				}
+
+				// Will Not store files on the server unless StorageStrategy is provided which is desired for this use case
+				try {
+					Media::insert($data);
+					if ($errors = Media::getErrors()) {
+						$this->logOrEcho('ERROR: ' . array_pop($errors));
+					} else {
+						$this->logOrEcho($LANG['IMAGE_LOADED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+						$status = true;
+					}
+				} catch (MediaException $th) {
+					$message = $th->getMessage();
+
+					$this->logOrEcho('ERROR: ' . $message);
+					$this->logOrEcho("Ensure mapping links point directly at the media file", 1, 'div');
+					if (strpos($message, ' text ')) {
+						$this->logOrEcho("Linking webpages is supported via the sourceUrl field", 1, 'div');
+					}
+				} catch (Throwable $th) {
+					$this->logOrEcho('ERROR: ' . $th->getMessage());
+				}
+			}
+		} elseif ($this->importType == self::IMPORT_DETERMINATIONS) {
+			$detManager = new OmDeterminations($this->conn);
+			foreach ($occidArr as $occid) {
+				$detManager->setOccid($occid);
+				$fieldArr = array_keys($detManager->getSchemaMap());
+				$detArr = array();
+				foreach ($fieldArr as $field) {
+					$fieldLower = strtolower($field);
+					if (isset($this->fieldMap[$fieldLower]) && !empty($recordArr[$this->fieldMap[$fieldLower]])) $detArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
+				}
+				if (empty($detArr['sciname'])) {
+					$this->logOrEcho('ERROR loading determination: Scientific name is empty.', 1);
+					continue;
+				}
+				if (empty($detArr['identifiedBy'])) {
+					$paramArr['identifiedBy'] = 'unknown';
+				}
+				if (empty($detArr['dateIdentified'])) {
+					$paramArr['dateIdentified'] = 's.d.';
+				}
+				if ($detManager->insertDetermination($detArr)) {
+					 $this->logOrEcho($LANG['DETERMINATION_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+                    $status = true;
+				} else {
+					$this->logOrEcho('ERROR loading determination: ' . $detManager->getErrorMessage(), 1);
+				}
+			}
+		} elseif ($this->importType == self::IMPORT_ASSOCIATIONS) {
+			$importManager = new OmAssociations($this->conn);
+			foreach ($occidArr as $occid) {
+				$importManager->setOccid($occid);
+				$fieldArr = array_keys($importManager->getSchemaMap());
+				$fieldArr[] = 'object-occurrenceID';
+				$fieldArr[] = 'object-catalogNumber';
+				$assocArr = array();
+				foreach ($fieldArr as $field) {
+					$fieldLower = strtolower($field);
+					if (isset($this->fieldMap[$fieldLower])) $assocArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
+				}
+				if ($assocArr) {
+					if (!empty($postArr['associationType']) && !empty($postArr['relationship'])) {
+						$assocArr['associationType'] = $postArr['associationType'];
+						$assocArr['relationship'] = $postArr['relationship'];
+						if (isset($postArr['subType']) && empty($assocArr['subType'])) $assocArr['subType'] = $postArr['subType'];
+						if (!empty($postArr['replace'])) {
+							$existingAssociation = null;
+							if (!empty($assocArr['instanceID'])) {
+								$existingAssociation = $importManager->getAssociationArr(array('associationType' => $assocArr['associationType'], 'recordID' => $assocArr['instanceID']));
+								if ($existingAssociation) {
+									//instanceID is recordID, thus don't add to instanceID
+									unset($assocArr['instanceID']);
+								}
+								if (!$existingAssociation) {
+									$existingAssociation = $importManager->getAssociationArr(array('associationType' => $assocArr['associationType'], 'instanceID' => $assocArr['instanceID']));
+								}
+							}
+							if (!$existingAssociation && !empty($assocArr['resourceUrl'])) {
+								$existingAssociation = $importManager->getAssociationArr(array('associationType' => $assocArr['associationType'], 'resourceUrl' => $assocArr['resourceUrl']));
+							}
+							if (!$existingAssociation && !empty($assocArr['objectID'])) {
+								$existingAssociation = $importManager->getAssociationArr(array('associationType' => $assocArr['associationType'], 'objectID' => $assocArr['objectID']));
+							}
+							if ($existingAssociation) {
+								if ($assocID = key($existingAssociation)) {
+									$importManager->setAssocID($assocID);
+									if ($assocArr['relationship'] == 'DELETE') {
+										if ($importManager->deleteAssociation()) {
+                                            $this->logOrEcho($LANG['ASSOC_DELETED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+
+										} else {
+											$this->logOrEcho($LANG['ERROR_DELETING'] . ': ' . $importManager->getErrorMessage(), 1);
+										}
+									} else {
+										if ($importManager->updateAssociation($assocArr)) {
+						                    $this->logOrEcho($LANG['ASSOC_UPDATED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+                                            $status = true;
+										} else {
+											$this->logOrEcho($LANG['ERROR_UPDATING'] . ': ' . $importManager->getErrorMessage(), 1);
+										}
+									}
+								}
+							} else {
+								$this->logOrEcho($LANG['TARGET_NOT_FOUND'], 1);
+							}
+						} elseif ($importManager->insertAssociation($assocArr)) {
+							$this->logOrEcho($LANG['ASSOC_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+
+                            $status = true;
+						} else {
+							$this->logOrEcho($LANG['ERROR_ADDING'] . ': ' . $importManager->getErrorMessage(), 1);
+						}
+					}
+				}
+			}
+		} elseif ($this->importType == self::IMPORT_MATERIAL_SAMPLE) {
+			$importManager = new OmMaterialSample($this->conn);
+			foreach ($occidArr as $occid) {
+				$importManager->setOccid($occid);
+				$fieldArr = array_keys($importManager->getSchemaMap());
+				$msArr = array();
+				foreach ($fieldArr as $field) {
+					$fieldLower = strtolower($field);
+					if (isset($this->fieldMap[$fieldLower]) && !empty($recordArr[$this->fieldMap[$fieldLower]])) $msArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
+				}
+				if (isset($msArr['ms_catalogNumber']) && $msArr['ms_catalogNumber']) {
+					$msArr['catalogNumber'] = $msArr['ms_catalogNumber'];
+					unset($msArr['ms_catalogNumber']);
+				}
+				if ($importManager->insertMaterialSample($msArr)) {
+					$this->logOrEcho($LANG['MAT_SAMPLE_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+                    $status = true;
+				} else {
+					$this->logOrEcho('ERROR loading Material Sample: ' . $importManager->getErrorMessage(), 1);
+				}
+			}
+		} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
+			$importManager = new OmIdentifiers($this->conn);
+			foreach ($occidArr as $occid) {
+				$importManager->setOccid($occid);
+				$fieldArr = array_keys($importManager->getSchemaMap());
+				$identifierArr = array();
+				foreach ($fieldArr as $field) {
+					$fieldLower = strtolower($field);
+					if ($fieldLower == 'occid') {
+						$identifierArr[$field] = $occid;
+					} else {
+						if (isset($this->fieldMap[$fieldLower])) $identifierArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
+					}
+				}
+				if (empty($identifierArr['occid'])) {
+					$this->logOrEcho('ERROR loading identifier: occid could not be fetched from provided occurrence identifiers.', 1);
+					continue;
+				}
+				if (empty($identifierArr['identifierValue'])) {
+					$this->logOrEcho('ERROR loading identifier: identifierValue is empty.', 1);
+					continue;
+				}
+				if (empty($identifierArr['identifierName'])) {
+					$this->logOrEcho('ERROR loading identifier: identifierName is empty.', 1);
+					continue;
+				}
+				if ($identifierArr) {
+					$existingIdentifier = null;
+					$existingIdentifier = $importManager->getIdentifier($occid, $identifierArr['identifierName']);
+					if ($existingIdentifier) {
+						$importManager->setIdentifierID($existingIdentifier);
+						if ($postArr['action'] == 'delete') {
+							$status = $importManager->deleteIdentifier();
+							$this->logOrEcho($LANG['IDENTIFIER_DELETED'], 1);
+						}
+						if (!empty($postArr['replace-identifier'])) {
+							$status = $importManager->updateIdentifier($identifierArr);
+                            $this->logOrEcho($LANG['IDENTIFIER_UPDATED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+						}
+					}
+					if (!$existingIdentifier) {
+						$status = $importManager->insertIdentifier($identifierArr);
+						$this->logOrEcho($LANG['IDENTIFIER_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+					}
+					if (!$status) {
+						if ($existingIdentifier) {
+							$this->logOrEcho('ERROR loading identifier: existing identifier detected. ' . $importManager->getErrorMessage(), 1);
+						} else {
+							$this->logOrEcho('ERROR loading identifier. ' . $importManager->getErrorMessage(), 1);
+						}
+					}
+				}
+			}
+		}
+        elseif ($this->importType == self::UPDATE_OCCURRENCE) {
+			$importManager = new OmoccurrenceEditor($this->conn);
+			foreach ($occidArr as $occid) {
+				$importManager->setOccid($occid);
+				$fieldArr = array_keys($importManager->getSchemaMap());
+                $occurrenceArr = array();
+				foreach ($fieldArr as $field) {
+					$fieldLower = strtolower($field);
+					if ($fieldLower == 'id') {
+						$occurrenceArr[$field] = $occid;
+					} else {
+						if (isset($this->fieldMap[$fieldLower])) $occurrenceArr[$field] = $this->encodeString($recordArr[$this->fieldMap[$fieldLower]]);
+					}
+				}
+				if (empty($occurrenceArr['id'])) {
+					$this->logOrEcho('ERROR: occid could not be fetched from provided occurrence identifiers.', 1);
+					continue;
+				}
+				if ($occurrenceArr['id']) {
+						$importManager->setOccurrenceID($occurrenceArr['id']);
+							$status = $importManager->updateOccurrence($occurrenceArr);
+						    $this->logOrEcho('Occurrence Updated' . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+					if (!$status) {
+							$this->logOrEcho('ERROR updating occurrence. ' . $importManager->getErrorMessage(), 1);
+					}
+				}
+			}
+		}
+		return $status;
+	}
+
+	//Identifier and occid functions
+	protected function getOccurrencePK($identifierArr) {
+		$retArr = array();
+		$sql = 'SELECT DISTINCT o.occid FROM omoccurrences o ';
+		$sqlConditionArr = array();
+		if (isset($identifierArr['occid'])) {
+			$occid = $this->cleanInStr($identifierArr['occid']);
+			$sqlConditionArr[] = '(o.occid = "' . $occid . '" OR o.recordID = "' . $occid . '")';
+		}
+		if (isset($identifierArr['occurrenceID'])) {
+			$occurrenceID = $this->cleanInStr($identifierArr['occurrenceID']);
+			$sqlConditionArr[] = '(o.occurrenceID = "' . $occurrenceID . '" OR o.recordID = "' . $occurrenceID . '")';
+		}
+		if (isset($identifierArr['catalogNumber'])) {
+			$sqlConditionArr[] = '(o.catalogNumber = "' . $this->cleanInStr($identifierArr['catalogNumber']) . '")';
+		}
+		if (isset($identifierArr['otherCatalogNumbers'])) {
+			$otherCatalogNumbers = $this->cleanInStr($identifierArr['otherCatalogNumbers']);
+			$sqlConditionArr[] = '(o.othercatalognumbers = "' . $otherCatalogNumbers . '" OR i.identifierValue = "' . $otherCatalogNumbers . '")';
+			$sql .= 'LEFT JOIN omoccuridentifiers i ON o.occid = i.occid ';
+		}
+		if ($sqlConditionArr) {
+			$sql .= 'WHERE (' . implode(' OR ', $sqlConditionArr) . ') ';
+			$rs = $this->conn->query($sql);
+			while ($r = $rs->fetch_object()) {
+				$retArr[] = $r->occid;
+			}
+			$rs->free();
+		}
+		if (!$retArr) {
+            $this->logOrEcho('SKIPPED: Unable to find record matching any provided identifier(s): ' . implode(', ', $identifierArr), 1);
+		}
+
+		return $retArr;
+	}
+
+	//Mapping functions
+	public function setTargetFieldArr($associationType = null) {
+		$this->targetFieldMap['catalognumber'] = 'subject identifier: catalogNumber';
+		$this->targetFieldMap['othercatalognumbers'] = 'subject identifier: otherCatalogNumbers';
+		$this->targetFieldMap['occurrenceid'] = 'subject identifier: occurrenceID';
+		$this->targetFieldMap['occid'] = 'subject identifier: occid';
+		$this->targetFieldMap[''] = '------------------------------------';
+		$fieldArr = array();
+		if ($this->importType == self::IMPORT_IMAGE_MAP) {
+			$fieldArr = array(
+				'url',
+				'thumbnailUrl',
+				'sourceUrl',
+				'archiveUrl',
+				'referenceUrl',
+				'creator',
+				'creatorUid',
+				'caption',
+				'owner',
+				'anatomy',
+				'notes',
+				'format',
+				'sourceIdentifier',
+				'hashFunction',
+				'hashValue',
+				'mediaMD5',
+				'copyright',
+				'rights',
+				'accessRights',
+				'sortOccurrence'
+			);
+
+			$this->targetFieldMap['originalurl'] = 'originalUrl (required)';
+		} elseif ($this->importType == self::IMPORT_ASSOCIATIONS) {
+			$fieldArr = array('relationshipID', 'objectID', 'basisOfRecord', 'establishedDate', 'notes', 'accordingTo');
+			if ($associationType == 'resource') {
+				$fieldArr[] = 'resourceUrl';
+			} elseif ($associationType == 'internalOccurrence') {
+				$this->targetFieldMap['object-catalognumber'] = 'object identifier: catalogNumber';
+				$this->targetFieldMap['object-occurrenceid'] = 'object identifier: occurrenceID';
+				$this->targetFieldMap['occidassociate'] = 'object identifier: occid';
+				$this->targetFieldMap['0'] = '------------------------------------';
+			} elseif ($associationType == 'externalOccurrence') {
+				$fieldArr[] = 'verbatimSciname';
+				$fieldArr[] = 'resourceUrl';
+			} elseif ($associationType == 'observational') {
+				$fieldArr[] = 'verbatimSciname';
+			}
+		} elseif ($this->importType == self::IMPORT_DETERMINATIONS) {
+			$detManager = new OmDeterminations($this->conn);
+			$schemaMap = $detManager->getSchemaMap();
+			unset($schemaMap['appliedStatus']);
+			unset($schemaMap['detType']);
+			$fieldArr = array_keys($schemaMap);
+		} elseif ($this->importType == self::IMPORT_MATERIAL_SAMPLE) {
+			$fieldArr = array(
+				'sampleType',
+				'ms_catalogNumber',
+				'guid',
+				'sampleCondition',
+				'disposition',
+				'preservationType',
+				'preparationDetails',
+				'preparationDate',
+				'preparedByUid',
+				'individualCount',
+				'sampleSize',
+				'storageLocation',
+				'remarks'
+			);
+		} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
+			$fieldArr = array(
+				// 'occid',
+				'identifierValue',
+				'identifierName',
+				// 'format',
+				// 'notes',
+				// 'sortBy',
+			);
+		}
+        elseif ($this->importType == self::UPDATE_OCCURRENCE) {
+			$detManager = new OmOccurrenceEditor($this->conn);
+			$schemaMap = $detManager->getSchemaMap();
+			$fieldArr = array_keys($schemaMap);
+		}
+		sort($fieldArr);
+		foreach ($fieldArr as $field) {
+			$this->targetFieldMap[strtolower($field)] = $field;
+		}
+	}
+
+	private function defineTranslationMap() {
+		if ($this->translationMap === null) {
+			if ($this->importType == self::IMPORT_IMAGE_MAP) {
+				$this->translationMap = array(
+					'web' => 'url',
+					'webviewoptional' => 'url',
+					'thumbnail' => 'thumbnailurl',
+					'thumbnailoptional' => 'thumbnailurl',
+					'largejpg' => 'originalurl',
+					'large' => 'originalurl',
+					'imageurl' => 'url',
+					'accessuri' => 'url'
+				);
+			} elseif ($this->importType == self::IMPORT_ASSOCIATIONS) {
+				$this->translationMap = array();
+			} elseif ($this->importType == self::IMPORT_DETERMINATIONS) {
+				$this->translationMap = array('identificationid' => 'sourceIdentifier');
+			} elseif ($this->importType == self::IMPORT_MATERIAL_SAMPLE) {
+				$this->translationMap = array();
+			} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
+				$this->translationMap = array();
+			}
+            elseif ($this->importType == self::UPDATE_OCCURRENCE) {
+				$this->translationMap = array();
+			}
+		}
+	}
+
+	//Data set functions
+
+
+	public function getControlledVocabulary($tableName, $fieldName, $filterVariable = '') {
+		$retArr = array();
+		$sql = 'SELECT t.term, t.termDisplay
+			FROM ctcontrolvocab v INNER JOIN ctcontrolvocabterm t ON v.cvID = t.cvID
+			WHERE tableName = ? AND fieldName = ? AND filterVariable = ?';
+		if ($stmt = $this->conn->prepare($sql)) {
+			$stmt->bind_param('sss', $tableName, $fieldName, $filterVariable);
+			$stmt->execute();
+			$term = '';
+			$termDisplay = '';
+			$stmt->bind_result($term, $termDisplay);
+			while ($stmt->fetch()) {
+				if (!$termDisplay) $termDisplay = $term;
+				$retArr[$term] = $termDisplay;
+			}
+			$stmt->close();
+		}
+		asort($retArr);
+		return $retArr;
+	}
+
+	//Basic setters and getters
+
+	public function setCreateNewRecord($b) {
+		if ($b) $this->createNewRecord = true;
+		else $this->createNewRecord = false;
+	}
+
+	public function setImportType($importType) {
+		if (is_numeric($importType)) $this->importType = $importType;
+		$this->defineTranslationMap();
+	}
+}

--- a/neon/classes/NeonEditor.php
+++ b/neon/classes/NeonEditor.php
@@ -6,6 +6,7 @@ include_once('OmAssociations.php');
 include_once('OmDeterminations.php');
 include_once('OmIdentifiers.php');
 include_once('OmOccurrenceEditor.php');
+include_once('OmGenetic.php');
 include_once('OccurrenceMaintenance.php');
 include_once('Media.php');
 include_once('utilities/UuidFactory.php');
@@ -23,6 +24,7 @@ class NeonEditor extends UtilitiesFileImport {
 	private const IMPORT_MATERIAL_SAMPLE = 4;
 	private const IMPORT_IDENTIFIERS = 5;
     private const UPDATE_OCCURRENCE = 6;
+	private const IMPORT_GENETIC = 7;
 
 	function __construct() {
 		parent::__construct(null, 'write');
@@ -350,6 +352,37 @@ class NeonEditor extends UtilitiesFileImport {
                 }
             }
         }
+		elseif ($this->importType == self::IMPORT_GENETIC) {
+			$importManager = new OmGenetic($this->conn);
+			foreach ($occidArr as $occid) {
+				$importManager->setOccid($occid);
+				$fieldArr = array_keys($importManager->getSchemaMap());
+				$genArr = array();
+					foreach ($fieldArr as $field) {
+						$fieldLower = strtolower($field);
+						if (isset($this->fieldMap[$fieldLower])) {
+							$value = $recordArr[$this->fieldMap[$fieldLower]] ?? null;
+							$genArr[$field] = $this->encodeString($value);
+						}
+					}
+				}
+				if($postArr['action'] == 'add'){
+					if ($importManager->insertGeneticLink($genArr) ) {
+						$this->logOrEcho('Genetic links loaded: <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+						$status = true;
+						} else {
+						$this->logOrEcho('ERROR loading Genetic Link: ' . $importManager->getErrorMessage(), 1);
+					}
+				} elseif($postArr['action'] == 'update'){
+					if ($importManager->updateGeneticLink($genArr) ) {
+						$this->logOrEcho('Genetic links updated: <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+						$status = true;
+					} else {
+						$this->logOrEcho('ERROR updating Genetic Link: ' . $importManager->getErrorMessage(), 1);
+					}
+				}
+
+			}
 		return $status;
 	}
 
@@ -486,6 +519,17 @@ class NeonEditor extends UtilitiesFileImport {
 			$schemaMap = $detManager->getSchemaMap();
 			$fieldArr = array_keys($schemaMap);
 		}
+		elseif ($this->importType == self::IMPORT_GENETIC) {
+			$fieldArr = array(
+				'occid',
+				'identifier',
+				'resourcename',
+				'title',
+				'locus',
+				'resourceurl',
+				'notes'
+			);
+		}
 		sort($fieldArr);
 		foreach ($fieldArr as $field) {
 			$this->targetFieldMap[strtolower($field)] = $field;
@@ -514,6 +558,9 @@ class NeonEditor extends UtilitiesFileImport {
 			} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
 				$this->translationMap = array();
 			} elseif ($this->importType == self::UPDATE_OCCURRENCE) {
+				$this->translationMap = array();
+			}
+			elseif ($this->importType == self::IMPORT_GENETIC) {
 				$this->translationMap = array();
 			}
 		}

--- a/neon/classes/OmGenetic.php
+++ b/neon/classes/OmGenetic.php
@@ -1,0 +1,225 @@
+<?php
+include_once($SERVER_ROOT . '/config/dbconnection.php');
+include_once($SERVER_ROOT . '/classes/utilities/OccurrenceUtil.php');
+include_once($SERVER_ROOT . '/classes/utilities/UuidFactory.php');
+
+class OmGenetic{
+
+	private $conn;
+	private $connInherited = false;
+	private $idoccurgenetic;
+	private $occid;
+	private $schemaMap = array();
+	private $parameterArr = array();
+	private $typeStr = '';
+	private $errorMessage;
+
+	function __construct($conn = null){
+		if($conn){
+			$this->conn = $conn;
+			$this->connInherited = true;
+		}
+		else $this->conn = MySQLiConnectionFactory::getCon('write');
+		$this->schemaMap = array('identifier' => 's', 'resourcename' => 's', 'title' => 's', 'locus' => 's', 'resourceurl' => 's','notes' => 's');
+	}
+
+	function __destruct(){
+		if(!($this->conn === null) && !$this->connInherited) $this->conn->close();
+	}
+
+	public function getGenLinkArr(){
+		$retArr = array();
+		$sql = 'SELECT g.idoccurgenetic, g.'.implode(', g.', array_keys($this->schemaMap)).', g.initialTimestamp
+			FROM omoccurgenetic g WHERE g.occid = '.$this->occid;
+		if($rs = $this->conn->query($sql)){
+			while($r = $rs->fetch_assoc()){
+				$retArr[$r['idoccurgenetic']] = $r;
+			}
+			$rs->free();
+		}
+		return $retArr;
+	}
+
+
+    public function insertGeneticLink($inputArr){
+        $status = false;
+
+        if ($this->occid && $this->conn) {
+            $this->setParameterArr($inputArr);
+
+            $identifier   = $this->parameterArr['identifier']   ?? null;
+            $resourcename = $this->parameterArr['resourcename'] ?? null;
+
+            $dupSql = 'SELECT idoccurgenetic 
+                    FROM omoccurgenetic 
+                    WHERE occid = ? AND identifier <=> ? AND resourcename <=> ? 
+                    LIMIT 1';
+            if ($stmt = $this->conn->prepare($dupSql)) {
+                $stmt->bind_param('iss', $this->occid, $identifier, $resourcename);
+                $stmt->execute();
+                $stmt->store_result();
+
+                if ($stmt->num_rows > 0) {
+                    $stmt->close();
+                    $this->errorMessage = "Duplicate record ignored: (occid={$this->occid}, identifier={$identifier}, resourcename={$resourcename}) already exists.";
+                    return false;
+                }
+                $stmt->close();
+            }
+
+            $sql = 'INSERT INTO omoccurgenetic(occid';
+            $sqlValues = '?';
+            $paramArr = array($this->occid);
+            $this->typeStr = 'i';
+
+            foreach ($this->parameterArr as $fieldName => $value) {
+                $sql .= ', ' . $fieldName;
+                $sqlValues .= ', ?';
+                $paramArr[] = $value;
+                $this->typeStr .= $this->schemaMap[$fieldName];
+            }
+            $sql .= ') VALUES(' . $sqlValues . ')';
+
+            if ($stmt = $this->conn->prepare($sql)) {
+                $stmt->bind_param($this->typeStr, ...$paramArr);
+                if ($stmt->execute()) {
+                    if ($stmt->affected_rows || !$stmt->error) {
+                        $this->idoccurgenetic = $stmt->insert_id;
+                        $status = true;
+                    } else {
+                        $this->errorMessage = 'ERROR inserting genetic record (2): ' . $stmt->error;
+                    }
+                } else {
+                    $this->errorMessage = 'ERROR inserting genetic record (1): ' . $stmt->error;
+                }
+                $stmt->close();
+            } else {
+                $this->errorMessage = 'ERROR preparing statement for genetic link insert: ' . $this->conn->error;
+            }
+        }
+        return $status;
+    }
+
+    public function updateGeneticLink($inputArr){
+        $status = false;
+        $this->setParameterArr($inputArr);
+
+        $identifier   = $this->parameterArr['identifier']   ?? null;
+        $resourcename = $this->parameterArr['resourcename'] ?? null;
+
+        if (!$identifier && !$resourcename) {
+            $this->errorMessage = "Cannot update: 'identifier' and 'resourcename' required to locate record.";
+            return false;
+        }
+
+        $dupSql = 'SELECT idoccurgenetic 
+                FROM omoccurgenetic 
+                WHERE occid = ? AND identifier <=> ? AND resourcename <=> ? 
+                LIMIT 1';
+        if ($stmt = $this->conn->prepare($dupSql)) {
+            $stmt->bind_param('iss', $this->occid, $identifier, $resourcename);
+            $stmt->execute();
+            $stmt->store_result();
+            $stmt->bind_result($foundID);
+
+            if ($stmt->num_rows === 0) {
+                $stmt->close();
+                $this->errorMessage = "No genetic link found for occid={$this->occid}, identifier={$identifier}, resourcename={$resourcename}.";
+                return false;
+            }
+
+            $stmt->fetch();
+            $this->idoccurgenetic = $foundID;
+            $stmt->close();
+        } else {
+            $this->errorMessage = "Error preparing statement to locate genetic link: " . $this->conn->error;
+            return false;
+        }
+
+        $paramArr = array();
+        $sqlFrag = '';
+        $typeStr = '';
+
+        foreach ($this->parameterArr as $fieldName => $value) {
+            if ($value === null || $value === '') {
+                echo 'WARNING: Field '. $fieldName . ' is null or empty in upload and will not be updated.<br>';
+                continue; // skip empty fields
+            }
+            $sqlFrag .= $fieldName . ' = ?, ';
+            $paramArr[] = $value;
+            $typeStr .= $this->schemaMap[$fieldName];
+        }
+
+        if (empty($paramArr)) {
+            $this->errorMessage = "No fields to update: all uploaded fields are empty or null.";
+            return false;
+        }
+
+        $paramArr[] = $this->idoccurgenetic;
+        $typeStr .= 'i';
+
+        $sql = 'UPDATE omoccurgenetic SET '.trim($sqlFrag, ', ').' WHERE idoccurgenetic = ?';
+
+        if ($stmt = $this->conn->prepare($sql)) {
+            $stmt->bind_param($typeStr, ...$paramArr);
+            $stmt->execute();
+
+            if ($stmt->affected_rows || !$stmt->error) {
+                $status = true;
+            } else {
+                $this->errorMessage = 'ERROR updating genetic link: '.$stmt->error;
+            }
+
+            $stmt->close();
+        } else {
+            $this->errorMessage = 'ERROR preparing statement for updating genetic link: '.$this->conn->error;
+        }
+
+        return $status;
+    }
+
+	private function setParameterArr($inputArr){
+		foreach($this->schemaMap as $field => $type){
+			$postField = '';
+			if(isset($inputArr[$field])) $postField = $field;
+			elseif(isset($inputArr[strtolower($field)])) $postField = strtolower($field);
+
+			if($postField){
+				$value = trim($inputArr[$postField]);
+				if($value === '') $value = null;
+				$this->parameterArr[$field] = $value;
+				$this->typeStr .= $type;
+			}
+		}
+		if(isset($inputArr['occid']) && $inputArr['occid'] && !$this->occid) $this->occid = $inputArr['occid'];
+	}
+
+	//Misc support functions
+	public function cleanFormData(&$postArr){
+		foreach($postArr as $k => $v){
+			if(substr($k,0,3) == 'ms_') $postArr[$k] = htmlspecialchars($v, ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE);
+		}
+	}
+
+	//Setters and getters
+	public function setGenLinkID($id){
+		if(is_numeric($id)) $this->idoccurgenetic = $id;
+	}
+
+	public function setOccid($id){
+		if(is_numeric($id)) $this->occid = $id;
+	}
+
+	public function getOccid(){
+		return $this->occid;
+	}
+
+	public function getSchemaMap(){
+		return $this->schemaMap;
+	}
+
+	public function getErrorMessage(){
+		return $this->errorMessage;
+	}
+}
+?>

--- a/neon/classes/OmOccurrenceEditor.php
+++ b/neon/classes/OmOccurrenceEditor.php
@@ -1,0 +1,115 @@
+<?php
+include_once('Manager.php');
+include_once('utilities/OccurrenceUtil.php');
+include_once('utilities/UuidFactory.php');
+
+class OmoccurrenceEditor extends Manager {
+
+	private $occid = null;
+	private $schemaMap = array();
+	private $parameterArr = array();
+	private $typeStr = '';
+
+	public function __construct($conn) {
+		parent::__construct(null, 'write', $conn);
+		$this->schemaMap = array('associatedCollectors' => "s",'availability' => "I",'coordinateUncertaintyInMeters' => "s",
+        'county' => "s",'decimalLatitude' => "s",'decimalLongitude' => "s",'disposition' => "s",'dynamicProperties' => "s",
+        'eventDate' => "s",'eventDate2' => "s",'eventID' => "s",'geodeticDatum' => "s",'habitat' => "s",'individualCount' => "s",
+        'lifeStage' => "s",'locality' => "s",'locationID' => "s",'maximumDepthInMeters' => "s",'maximumElevationInMeters' => "s",
+        'minimumDepthInMeters' => "s",'minimumElevationInMeters' => "s",'occurrenceRemarks' => "s",'preparations' => "s",
+        'recordedBy' => "s",'reproductiveCondition' => "s",'samplingProtocol' => "s",'sex' => "s",'stateProvince' => "s",
+        'verbatimDepth' => "s",'verbatimElevation' => "s");
+	}
+
+	public function __destruct() {
+		parent::__destruct();
+	}
+
+	public function getOccurrenceArr($occid) {
+		$idomoccuridentifiers = null;
+		$sql = 'SELECT idomoccuridentifiers FROM omoccuridentifiers WHERE id = ? AND identifierName = ?';
+		if ($stmt = $this->conn->prepare($sql)) {
+			$stmt->bind_param('is', $occid);
+			$stmt->execute();
+			$stmt->bind_result($idomoccuridentifiers);
+			$stmt->fetch();
+			$stmt->close();
+		}
+		return $idomoccuridentifiers;
+	}
+
+	public function updateOccurrence($inputArr) {
+		$status = false;
+		if ($this->occid && $this->conn) {
+			$occidPlaceholder = null;
+			$identifierNamePlaceholder = null;
+			if (array_key_exists('occid', $inputArr)) {
+				$occidPlaceholder = (int)$inputArr['occid'];
+				unset($inputArr['occid']);
+			}
+			if (array_key_exists('identifierName', $inputArr)) {
+				$identifierNamePlaceholder = $inputArr['identifierName'];
+				unset($inputArr['identifierName']);
+			}
+			$paramArr = array();
+			$paramArr[] = $GLOBALS['SYMB_UID'];
+			$this->typeStr .= 'i';
+			$this->setParameterArr($inputArr);
+			$sqlFrag = '';
+			foreach ($this->parameterArr as $fieldName => $value) {
+				if ($fieldName !== 'occid' || $fieldName !== 'identifierName') {
+					$sqlFrag .= $fieldName . ' = ?, ';
+					if ($fieldName == 'modifiedUid' && empty($value)) {
+						$value = $GLOBALS['SYMB_UID'];
+					}
+					$paramArr[] = $value;
+				}
+			}
+			$paramArr[] = $occidPlaceholder;
+			$paramArr[] = $identifierNamePlaceholder;
+			$this->typeStr .= 'is';
+			$sql = 'UPDATE IGNORE omoccuridentifiers SET modifiedTimestamp = now(), modifiedUid = ? , ' . trim($sqlFrag, ', ') . ' WHERE (occid = ? AND identifierName = ?)';
+			if ($stmt = $this->conn->prepare($sql)) {
+				$stmt->bind_param($this->typeStr, ...$paramArr);
+				$stmt->execute();
+				if ($stmt->affected_rows || !$stmt->error) $status = true;
+				else $this->errorMessage = 'ERROR updating omoccurassociations record: ' . $stmt->error;
+				$stmt->close();
+				$this->typeStr = '';
+			} else $this->errorMessage = 'ERROR preparing statement for updating omoccurassociations: ' . $this->conn->error;
+		}
+		return $status;
+	}
+
+	private function setParameterArr($inputArr) {
+		foreach ($this->schemaMap as $field => $type) {
+			$postField = '';
+			if (isset($inputArr[$field])) $postField = $field;
+			elseif (isset($inputArr[strtolower($field)])) $postField = strtolower($field);
+			if ($postField) {
+				$value = trim($inputArr[$postField]);
+				if ($value) {
+					$postField = strtolower($postField);
+					if ($postField == 'modifiedTimestamp') $value = OccurrenceUtil::formatDate($value);
+					if ($postField == 'modifieduid') $value = OccurrenceUtil::verifyUser($value, $this->conn);
+					if ($postField == 'sortBy') { 
+						if (!is_numeric($value)) $value = 10;
+					}
+				} else $value = null;
+				$this->parameterArr[$field] = $value;
+				$this->typeStr .= $type;
+			}
+		}
+		if (isset($inputArr['occid']) && $inputArr['occid'] && !$this->occid) $this->occid = $inputArr['occid'];
+	}
+
+	//Setters and getters
+	public function getSchemaMap() {
+		return $this->schemaMap;
+	}
+
+	public function setOccid($id) {
+		if (is_numeric($id)) $this->occid = $id;
+	}
+
+}

--- a/neon/classes/OmOccurrenceEditor.php
+++ b/neon/classes/OmOccurrenceEditor.php
@@ -25,83 +25,168 @@ class OmoccurrenceEditor extends Manager {
 		parent::__destruct();
 	}
 
-	public function getOccurrenceArr($occid) {
-		$idomoccuridentifiers = null;
-		$sql = 'SELECT idomoccuridentifiers FROM omoccuridentifiers WHERE id = ? AND identifierName = ?';
-		if ($stmt = $this->conn->prepare($sql)) {
-			$stmt->bind_param('is', $occid);
-			$stmt->execute();
-			$stmt->bind_result($idomoccuridentifiers);
-			$stmt->fetch();
-			$stmt->close();
-		}
-		return $idomoccuridentifiers;
-	}
+    public function getOccurArr($occid) {
+        $occurArr = null;
+        $sql = 'SELECT * FROM omoccurrences WHERE occid = ?';
+        if ($stmt = $this->conn->prepare($sql)) {
+            $stmt->bind_param('i', $occid);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            if ($result && $row = $result->fetch_assoc()) {
+                $occurArr = $row;
+            }
+            $stmt->close();
+        }
+        return $occurArr;
+    }
 
-	public function updateOccurrence($inputArr) {
-		$status = false;
-		if ($this->occid && $this->conn) {
-			$occidPlaceholder = null;
-			$identifierNamePlaceholder = null;
-			if (array_key_exists('occid', $inputArr)) {
-				$occidPlaceholder = (int)$inputArr['occid'];
-				unset($inputArr['occid']);
-			}
-			if (array_key_exists('identifierName', $inputArr)) {
-				$identifierNamePlaceholder = $inputArr['identifierName'];
-				unset($inputArr['identifierName']);
-			}
-			$paramArr = array();
-			$paramArr[] = $GLOBALS['SYMB_UID'];
-			$this->typeStr .= 'i';
-			$this->setParameterArr($inputArr);
-			$sqlFrag = '';
-			foreach ($this->parameterArr as $fieldName => $value) {
-				if ($fieldName !== 'occid' || $fieldName !== 'identifierName') {
-					$sqlFrag .= $fieldName . ' = ?, ';
-					if ($fieldName == 'modifiedUid' && empty($value)) {
-						$value = $GLOBALS['SYMB_UID'];
-					}
-					$paramArr[] = $value;
-				}
-			}
-			$paramArr[] = $occidPlaceholder;
-			$paramArr[] = $identifierNamePlaceholder;
-			$this->typeStr .= 'is';
-			$sql = 'UPDATE IGNORE omoccuridentifiers SET modifiedTimestamp = now(), modifiedUid = ? , ' . trim($sqlFrag, ', ') . ' WHERE (occid = ? AND identifierName = ?)';
-			if ($stmt = $this->conn->prepare($sql)) {
-				$stmt->bind_param($this->typeStr, ...$paramArr);
-				$stmt->execute();
-				if ($stmt->affected_rows || !$stmt->error) $status = true;
-				else $this->errorMessage = 'ERROR updating omoccurassociations record: ' . $stmt->error;
-				$stmt->close();
-				$this->typeStr = '';
-			} else $this->errorMessage = 'ERROR preparing statement for updating omoccurassociations: ' . $this->conn->error;
-		}
-		return $status;
-	}
 
-	private function setParameterArr($inputArr) {
-		foreach ($this->schemaMap as $field => $type) {
-			$postField = '';
-			if (isset($inputArr[$field])) $postField = $field;
-			elseif (isset($inputArr[strtolower($field)])) $postField = strtolower($field);
-			if ($postField) {
-				$value = trim($inputArr[$postField]);
-				if ($value) {
-					$postField = strtolower($postField);
-					if ($postField == 'modifiedTimestamp') $value = OccurrenceUtil::formatDate($value);
-					if ($postField == 'modifieduid') $value = OccurrenceUtil::verifyUser($value, $this->conn);
-					if ($postField == 'sortBy') { 
-						if (!is_numeric($value)) $value = 10;
-					}
-				} else $value = null;
-				$this->parameterArr[$field] = $value;
-				$this->typeStr .= $type;
-			}
-		}
-		if (isset($inputArr['occid']) && $inputArr['occid'] && !$this->occid) $this->occid = $inputArr['occid'];
-	}
+    public function updateOccurrence($inputArr, $occurArr, $postArr) {
+        $status = false;
+
+        if ($this->occid && $this->conn) {
+            $occidPlaceholder = null;
+            if (array_key_exists('occid', $inputArr)) {
+                $occidPlaceholder = (int)$inputArr['occid'];
+                unset($inputArr['occid']);
+            }
+
+            $paramArr = array();
+            $sqlFrag = '';
+            $fieldsToUpdate = [];
+            $oldValues = [];
+            $newValues = [];
+
+            if (!empty($postArr['action']) && $postArr['action'] === 'add') {
+                foreach ($inputArr as $field => $value) {
+                    if (!isset($occurArr[$field]) || is_null($occurArr[$field])) {
+                        $sqlFrag .= $field . ' = ?, ';
+                        $paramArr[] = $value;
+                        $fieldsToUpdate[] = $field;
+                        $oldValues[$field] = $occurArr[$field] ?? null;
+                        $newValues[$field] = $value;
+                    }
+                }
+            } else {
+                $this->setParameterArr($inputArr);
+                foreach ($this->parameterArr as $field => $value) {
+                    if ($field !== 'occid') {
+                        $sqlFrag .= $field . ' = ?, ';
+                        $paramArr[] = $value;
+                        $fieldsToUpdate[] = $field;
+                        $oldValues[$field] = $occurArr[$field] ?? null;
+                        $newValues[$field] = $value;
+                    }
+                }
+            }
+
+            if (!empty($fieldsToUpdate)) {
+                echo '<div style="color:green;">Updating fields: ' . implode(', ', $fieldsToUpdate) . '</div>';
+            } else {
+                echo '<div style="color:orange;">No fields to update for occid </div>';
+                return false; 
+            }
+
+            $sql = 'UPDATE omoccurrences SET dateLastModified = now(), ' . trim($sqlFrag, ', ') . ' WHERE (occid = ?)';
+
+            $paramArr[] = $occidPlaceholder;
+            $oldValues['occid'] = $occidPlaceholder;
+            $newValues['occid'] = $occidPlaceholder;
+
+            $typeStr = '';
+            foreach ($paramArr as $val) {
+                $typeStr .= is_int($val) ? 'i' : 's';
+            }
+
+            if ($stmt = $this->conn->prepare($sql)) {
+                $stmt->bind_param($typeStr, ...$paramArr);
+                $stmt->execute();
+                if ($stmt->affected_rows || !$stmt->error) {
+                    $status = true;
+                    if (array_key_exists('allow-overwrite',$postArr) && $postArr['allow-overwrite'] == 1) $user = 50;
+                    else ($user = $GLOBALS['SYMB_UID']);
+                    $this->recordEdits($oldValues,$newValues,$user);
+                }
+                else $this->errorMessage = 'ERROR updating occurrence record: ' . $stmt->error;
+                $stmt->close();
+            } else {
+                $this->errorMessage = 'ERROR preparing statement for updating omoccurrences: ' . $this->conn->error;
+            }
+        }
+
+        return $status;
+    }
+
+
+    public function recordEdits($oldValues, $newValues, $user) {
+
+        $occid = (int)$newValues['occid'];
+        foreach ($newValues as $field => $newVal) {
+            if ($field === 'occid') continue;
+
+            $oldVal = $oldValues[$field] ?? null;
+            if (is_null($oldVal)) $oldVal = '';
+            if (is_null($newVal)) $newVal = '';
+
+            if ($oldVal !== $newVal) {
+                $sql = 'INSERT INTO omoccuredits (
+                            occid,
+                            fieldName,
+                            fieldValueNew,
+                            fieldValueOld,
+                            reviewStatus,
+                            appliedStatus,
+                            editType,
+                            uid,
+                            initialTimestamp
+                        ) VALUES (?, ?, ?, ?, 1, 1, 1, ?, NOW())';
+                if ($stmt = $this->conn->prepare($sql)) {
+                    $stmt->bind_param('isssi', $occid, $field, $newVal, $oldVal, $user);
+                   if(!$stmt->execute()){
+                        echo "<div style='color:red;'>ERROR inserting edit for field '$field': " . $stmt->error . '</div>';
+                    }
+                    $stmt->close();
+                } else {
+                    echo "<div style='color:red;'>ERROR updaing field '$field': " . $this->conn->error . '</div>';
+                }
+            }
+        }
+        return true;
+    }
+
+
+    private function setParameterArr($inputArr) {
+        $inputArr = OccurrenceUtil::occurrenceArrayCleaning($inputArr);
+
+        foreach ($this->schemaMap as $field => $type) {
+            $postField = '';
+            if (isset($inputArr[$field])) {
+                $postField = $field;
+            } elseif (isset($inputArr[strtolower($field)])) {
+                $postField = strtolower($field);
+            }
+
+            if ($postField) {
+                $value = trim($inputArr[$postField]);
+                if ($value !== '') {
+                    $postFieldLower = strtolower($postField);
+                    if (in_array($postFieldLower, ['eventdate', 'eventdate2'])) {
+                        $value = OccurrenceUtil::formatDate($value);
+                    }
+                } else {
+                    $value = null;
+                }
+
+                $this->parameterArr[$field] = $value;
+                $this->typeStr .= $type;
+            }
+        }
+        if (isset($inputArr['occid']) && $inputArr['occid'] && !$this->occid) {
+            $this->occid = $inputArr['occid'];
+        }
+    }
+
+
 
 	//Setters and getters
 	public function getSchemaMap() {

--- a/neon/classes/OmOccurrenceEditor.php
+++ b/neon/classes/OmOccurrenceEditor.php
@@ -14,7 +14,8 @@ class OmoccurrenceEditor extends Manager {
 		parent::__construct(null, 'write', $conn);
 		$this->schemaMap = array('associatedCollectors' => "s",'availability' => "I",'coordinateUncertaintyInMeters' => "s",
         'county' => "s",'decimalLatitude' => "s",'decimalLongitude' => "s",'disposition' => "s",'dynamicProperties' => "s",
-        'eventDate' => "s",'eventDate2' => "s",'eventID' => "s",'geodeticDatum' => "s",'habitat' => "s",'individualCount' => "s",
+        'eventDate' => "s",'eventDate2' => "s",'day'=> "i",'month'=> "i",'year' => "i",'startDayOfYear' => "i",'endDayOfYear' => "i",
+        'eventID' => "s",'geodeticDatum' => "s",'habitat' => "s",'individualCount' => "s",
         'lifeStage' => "s",'locality' => "s",'locationID' => "s",'maximumDepthInMeters' => "s",'maximumElevationInMeters' => "s",
         'minimumDepthInMeters' => "s",'minimumElevationInMeters' => "s",'occurrenceRemarks' => "s",'preparations' => "s",
         'recordedBy' => "s",'reproductiveCondition' => "s",'samplingProtocol' => "s",'sex' => "s",'stateProvince' => "s",
@@ -57,14 +58,23 @@ class OmoccurrenceEditor extends Manager {
             $oldValues = [];
             $newValues = [];
 
+            if (isset($inputArr['eventDate']) || isset($inputArr['eventDate2'])) {
+                self::updateDateFields($inputArr);
+                foreach (['eventDate', 'eventDate2'] as $f) {
+                    if (!isset($inputArr[$f]) || $inputArr[$f] === '') {
+                        $inputArr[$f] = null;
+                    }
+                }
+            }
+
             if (!empty($postArr['action']) && $postArr['action'] === 'add') {
                 foreach ($inputArr as $field => $value) {
-                    if (!isset($occurArr[$field]) || is_null($occurArr[$field])) {
+                    if (!isset($occurArr[$field]) || is_null($occurArr[$field]) || $occurArr[$field] == '') {
                         $sqlFrag .= $field . ' = ?, ';
                         $paramArr[] = $value;
-                        $fieldsToUpdate[] = $field;
                         $oldValues[$field] = $occurArr[$field] ?? null;
                         $newValues[$field] = $value;
+                        if ($oldValues[$field] != $newValues[$field]) $fieldsToUpdate[] = $field;
                     }
                 }
             } else {
@@ -73,9 +83,9 @@ class OmoccurrenceEditor extends Manager {
                     if ($field !== 'occid') {
                         $sqlFrag .= $field . ' = ?, ';
                         $paramArr[] = $value;
-                        $fieldsToUpdate[] = $field;
                         $oldValues[$field] = $occurArr[$field] ?? null;
                         $newValues[$field] = $value;
+                        if ($oldValues[$field] != $newValues[$field]) $fieldsToUpdate[] = $field;
                     }
                 }
             }
@@ -83,7 +93,7 @@ class OmoccurrenceEditor extends Manager {
             if (!empty($fieldsToUpdate)) {
                 echo '<div style="color:green;">Updating fields: ' . implode(', ', $fieldsToUpdate) . '</div>';
             } else {
-                echo '<div style="color:orange;">No fields to update for occid </div>';
+                echo '<div style="color:orange;">No fields to update </div>';
                 return false; 
             }
 
@@ -116,6 +126,50 @@ class OmoccurrenceEditor extends Manager {
 
         return $status;
     }
+
+private static function updateDateFields(array &$recMap): void {
+    $dateStr = isset($recMap['eventDate']) ? trim($recMap['eventDate']) : '';
+    $dateStr2 = isset($recMap['eventDate2']) ? trim($recMap['eventDate2']) : '';
+    if ($dateStr === '') {
+        $recMap['eventDate'] = null;
+        $recMap['year'] = null;
+        $recMap['month'] = null;
+        $recMap['day'] = null;
+        $recMap['startDayOfYear'] = null;
+    } else {
+        $formatted = OccurrenceUtil::formatDate($dateStr);
+        if ($formatted) {
+            $recMap['eventDate'] = $formatted;
+            $date = date_create($formatted);
+            $recMap['year'] = (int)$date->format('Y');
+            $recMap['month'] = (int)$date->format('m');
+            $recMap['day'] = (int)$date->format('d');
+            $recMap['startDayOfYear'] = (int)$date->format('z') + 1;
+        } else {
+            echo "Invalid eventDate: $dateStr → NULL<br>";
+            $recMap['eventDate'] = null;
+            $recMap['year'] = null;
+            $recMap['month'] = null;
+            $recMap['day'] = null;
+            $recMap['startDayOfYear'] = null;
+        }
+    }
+    if ($dateStr2 === '') {
+        $recMap['eventDate2'] = null;
+        $recMap['endDayOfYear'] = null;
+    } else {
+        $formatted2 = OccurrenceUtil::formatDate($dateStr2);
+        if ($formatted2) {
+            $recMap['eventDate2'] = $formatted2;
+            $date2 = date_create($formatted2);
+            $recMap['endDayOfYear'] = (int)$date2->format('z') + 1;
+        } else {
+            echo "Invalid eventDate2: $dateStr2 → NULL<br>";
+            $recMap['eventDate2'] = null;
+            $recMap['endDayOfYear'] = null;
+        }
+    }
+}
 
 
     public function recordEdits($oldValues, $newValues, $user) {
@@ -156,34 +210,39 @@ class OmoccurrenceEditor extends Manager {
 
 
     private function setParameterArr($inputArr) {
+
         $inputArr = OccurrenceUtil::occurrenceArrayCleaning($inputArr);
 
         foreach ($this->schemaMap as $field => $type) {
-            $postField = '';
-            if (isset($inputArr[$field])) {
-                $postField = $field;
-            } elseif (isset($inputArr[strtolower($field)])) {
-                $postField = strtolower($field);
+            $postField = null;
+
+            foreach ($inputArr as $k => $v) {
+                if (strcasecmp($k, $field) === 0) {
+                    $postField = $k;
+                    break;
+                }
             }
 
-            if ($postField) {
-                $value = trim($inputArr[$postField]);
-                if ($value !== '') {
-                    $postFieldLower = strtolower($postField);
-                    if (in_array($postFieldLower, ['eventdate', 'eventdate2'])) {
-                        $value = OccurrenceUtil::formatDate($value);
-                    }
-                } else {
+            if ($postField === null) continue;
+
+            $value = $inputArr[$postField];
+
+            // Normalize string values
+            if (is_string($value)) {
+                $value = trim($value);
+                if ($value === '') {
                     $value = null;
                 }
-
-                $this->parameterArr[$field] = $value;
-                $this->typeStr .= $type;
             }
+
+            $this->parameterArr[$field] = $value;
+            $this->typeStr .= $type;
         }
+
         if (isset($inputArr['occid']) && $inputArr['occid'] && !$this->occid) {
-            $this->occid = $inputArr['occid'];
+            $this->occid = (int)$inputArr['occid'];
         }
+
     }
 
 

--- a/neon/editor/neoneditor.php
+++ b/neon/editor/neoneditor.php
@@ -12,6 +12,7 @@ $associationType = array_key_exists('associationType', $_POST) ? $_POST['associa
 $createNew = array_key_exists('createNew', $_POST) ? filter_var($_POST['createNew'], FILTER_SANITIZE_NUMBER_INT) : 0;
 $fileName = array_key_exists('fileName', $_POST) ? $_POST['fileName'] : '';
 $action = array_key_exists('submitAction', $_POST) ? $_POST['submitAction'] : '';
+$user = array_key_exists('user', $_POST) ? $_POST['user'] : '';
 
 $importManager = new NeonEditor();
 $importManager->setImportType($importType);
@@ -350,7 +351,7 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 									</select>
 								</div>
 								<div class="formField-div">
-									<input name="prevent-overwrite" type="checkbox" value="1">
+									<input name="allow-overwrite" type="checkbox" value="1">
 									<label for="allow-overwrite"><?= 'Allow additions or edits to be overwritten during reharvest' ?></label>
 								</div>
 							<?php
@@ -358,6 +359,7 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 							?>
 							<div style="margin:15px;">
 								<input name="importType" type="hidden" value="<?= $importType ?>">
+								<input name="user" type="hidden" value"<?= $SYMB_UID ?>">"
 								<input name="fileName" type="hidden" value="<?= htmlspecialchars($importManager->getFileName(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) ?>">
 								<button name="submitAction" type="submit" value="importData"><?= $LANG['IMPORT_DATA'] ?></button>
 							</div>

--- a/neon/editor/neoneditor.php
+++ b/neon/editor/neoneditor.php
@@ -222,7 +222,7 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 	<div role="main" id="innertext">
 		<h1 class="page-heading"><?= 'NEON Data Importer/Editor' ?></h1>
 		<div class="pageDescription-div">
-			<?= 'Example batch upload instructions and mapping details:' ?>:
+			<?= 'Example batch upload instructions and mapping details' ?>:
 			<ul>
 				<li><a href="https://docs.symbiota.org/Collection_Manager_Guide/Importing_Uploading/linked_resources" target="_blank"><?= $LANG['ASSOCIATIONS'] ?></a></li>
 				<?php if ($IS_ADMIN) echo '<li><a href="https://docs.symbiota.org/Portal_Manager_Guide/importing_determinations" target="_blank">' . $LANG['DETERMINATIONS'] . '</a></li>'; ?>
@@ -359,7 +359,7 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 							?>
 							<div style="margin:15px;">
 								<input name="importType" type="hidden" value="<?= $importType ?>">
-								<input name="user" type="hidden" value"<?= $SYMB_UID ?>">"
+								<input name="user" type="hidden" value="<?= $SYMB_UID ?>">
 								<input name="fileName" type="hidden" value="<?= htmlspecialchars($importManager->getFileName(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) ?>">
 								<button name="submitAction" type="submit" value="importData"><?= $LANG['IMPORT_DATA'] ?></button>
 							</div>

--- a/neon/editor/neoneditor.php
+++ b/neon/editor/neoneditor.php
@@ -1,0 +1,421 @@
+<?php
+include_once('../../config/symbini.php');
+include_once($SERVER_ROOT . '/neon/classes/NeonEditor.php');
+if ($LANG_TAG != 'en' && !file_exists($SERVER_ROOT . '/content/lang/collections/admin/importextended.' . $LANG_TAG . '.php')) $LANG_TAG = 'en';
+include_once($SERVER_ROOT . '/content/lang/collections/admin/importextended.' . $LANG_TAG . '.php');
+header('Content-Type: text/html; charset=' . $CHARSET);
+
+if (!$SYMB_UID) header('Location: ../../profile/index.php?refurl=../neon/neoneditor/neoneditor.php?' . htmlspecialchars($_SERVER['QUERY_STRING'], ENT_QUOTES));
+
+$importType = array_key_exists('importType', $_REQUEST) ? filter_var($_REQUEST['importType'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$associationType = array_key_exists('associationType', $_POST) ? $_POST['associationType'] : '';
+$createNew = array_key_exists('createNew', $_POST) ? filter_var($_POST['createNew'], FILTER_SANITIZE_NUMBER_INT) : 0;
+$fileName = array_key_exists('fileName', $_POST) ? $_POST['fileName'] : '';
+$action = array_key_exists('submitAction', $_POST) ? $_POST['submitAction'] : '';
+
+$importManager = new NeonEditor();
+$importManager->setImportType($importType);
+$importManager->setFileName($fileName);
+
+$isEditor = false;
+if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
+	$isEditor = true;
+}
+?>
+<!DOCTYPE html>
+<html lang="<?= $LANG_TAG ?>">
+
+<head>
+	<title><?= 'NEON Data Editor'?> </title>
+	<?php
+	include_once($SERVER_ROOT . '/includes/head.php');
+	?>
+	<script>
+		function verifyFileSize(inputObj) {
+			if (!window.FileReader) {
+				//alert("The file API isn't supported on this browser yet.");
+				return;
+			}
+			<?php
+			$maxUpload = ini_get('upload_max_filesize');
+			$maxUpload = str_replace("M", "000000", $maxUpload);
+			if ($maxUpload > 10000000) $maxUpload = 10000000;
+			echo 'var maxUpload = ' . $maxUpload . ";\n";
+			?>
+			var file = inputObj.files[0];
+			if (file.size > maxUpload) {
+				var msg = "<?= $LANG['IMPORT_FILE'] ?>" + file.name + " (" + Math.round(file.size / 100000) / 10 + "<?= $LANG['IS_TOO_BIG'] ?>" + (maxUpload / 1000000) + "MB).";
+				if (file.name.slice(-3) != "zip") msg = msg + "<?= $LANG['MAYBE_ZIP'] ?>";
+				alert(msg);
+			}
+		}
+
+		function validateInitiateForm(f) {
+			if (f.importFile.value == "") {
+				alert("<?= $LANG['SELECT_FILE'] ?>");
+				return false;
+			}
+			if (f.importType.value == "") {
+				alert("<?= $LANG['SELECT_IMPORT_TYPE'] ?>");
+				return false;
+			} else if (f.importType.value == 1 && f.associationType.value == "") {
+				alert("<?= $LANG['SELECT_ASSOC_TYPE'] ?>");
+				return false;
+			}
+			return true;
+		}
+
+
+		function validateMappingForm(f) {
+			let sourceArr = [];
+			let targetArr = [];
+			let requiredFieldArr = [];
+			<?php
+			if ($associationType == 'resource' || $associationType == 'externalOccurrence') {
+				echo 'requiredFieldArr["resourceUrl"] = 0; ';
+			} elseif ($associationType == 'observational') {
+				echo 'requiredFieldArr["verbatimSciname"] = 0; ';
+			}
+			?>
+			let subjectIdentifierIsMapped = false;
+			let identifierNameIsMapped = false;
+			let identifierValueIsMapped = false;
+			let objectIdentifierIsMapped = false;
+
+			const form_data = new FormData(f);
+
+			for (const [key, value] of form_data.entries()) {
+				if (key.substring(0, 3) == "sf[") {
+					if (sourceArr.indexOf(value) > -1) {
+						alert("<?= $LANG['ERR_DUPLICATE_SOURCE'] ?>" + value + ")");
+						return false;
+					}
+					sourceArr[sourceArr.length] = value;
+				} else if (value != "") {
+					if (key.substring(0, 3) == "tf[") {
+						if (targetArr.indexOf(value) > -1) {
+							alert("<?= $LANG['ERR_DUPLICATE_TARGET'] ?>" + value + ")");
+							return false;
+						}
+						targetArr[targetArr.length] = value;
+					}
+				}
+				if (key.substring(0, 3) == "tf[") {
+					if (value == "catalognumber") {
+						subjectIdentifierIsMapped = true;
+					} else if (value == "othercatalognumbers") {
+						subjectIdentifierIsMapped = true;
+					} else if (value == "occurrenceid") {
+						subjectIdentifierIsMapped = true;
+					} else if (value == "occid") {
+						subjectIdentifierIsMapped = true;
+					}
+					if (value == "identifiername") {
+						identifierNameIsMapped = true;
+					}
+
+					if (value == 'identifiervalue') {
+						identifierValueIsMapped = true;
+					}
+					<?php
+					if ($associationType == 'internalOccurrence') {
+					?>
+						if (value == "object-catalognumber") {
+							objectIdentifierIsMapped = true;
+						} else if (value == "object-occurrenceid") {
+							objectIdentifierIsMapped = true;
+						} else if (value == "occidassociate") {
+							objectIdentifierIsMapped = true;
+						}
+					<?php
+					}
+					?>
+					for (const fieldName2 in requiredFieldArr) {
+						if (value == fieldName2.toLowerCase()) requiredFieldArr[fieldName2] = 1;
+					}
+				}
+			}
+			if (!subjectIdentifierIsMapped && $importType==="5") {
+				alert("<?= $LANG['SUBJECT_ID_REQUIRED'] ?>");
+				return false;
+			}
+			if (!identifierNameIsMapped && $importType==="5") {
+				alert("<?= $LANG['IDENTIFIER_NAME_REQUIRED'] ?>");
+				return false;
+			}
+			if (!identifierValueIsMapped && $importType==="5") {
+				alert("<?= $LANG['IDENTIFIER_ID_VALUE_REQUIRED'] ?>");
+				return false;
+			}
+			<?php
+			if ($associationType == 'internalOccurrence') {
+			?>
+				if (!objectIdentifierIsMapped) {
+					alert("<?= $LANG['OBJECT_ID_REQUIRED'] ?>");
+					return false;
+				}
+			<?php
+			}
+			?>
+			if (f.relationship && f.relationship.value == "") {
+				alert("<?= $LANG['SELECT_RELATIONSHIP'] ?>");
+				return false;
+			}
+			for (const fieldName in requiredFieldArr) {
+				if (requiredFieldArr[fieldName] == 0) {
+					alert(fieldName + " is a required import field");
+					return false;
+				}
+			}
+			return true;
+		}
+
+		function importTypeChanged(selectElement) {
+			let f = selectElement.form;
+			if (selectElement.value == 1) {
+				document.getElementById("associationType-div").style.display = "block";
+			} else {
+				document.getElementById("associationType-div").style.display = "none";
+			}
+		}
+	</script>
+	<style>
+		.formField-div {
+			margin: 10px;
+		}
+
+		label {
+			font-weight: bold;
+		}
+
+		fieldset {
+			margin: 10px;
+			padding: 10px;
+		}
+
+		legend {
+			font-weight: bold;
+		}
+
+		.index-li {
+			margin-left: 10px;
+		}
+
+		button {
+			margin: 10px 15px
+		}
+	</style>
+</head>
+
+<body>
+	<?php
+	$displayLeftMenu = false;
+	include($SERVER_ROOT . '/includes/header.php');
+	?>
+	<div class="navpath">
+		<a href="../../index.php"><?= $LANG['HOME'] ?></a> &gt;&gt;
+		<a href="../index.php"><?= 'NEON Biorepository Tools' ?></a> &gt;&gt;
+		<b><?= 'NEON Occurrence Editor'?></b>
+	</div>
+	<!-- This is inner text! -->
+	<div role="main" id="innertext">
+		<h1 class="page-heading"><?= 'NEON Data Importer/Editor' ?></h1>
+		<div class="pageDescription-div">
+			<?= 'Example batch upload instructions and mapping details:' ?>:
+			<ul>
+				<li><a href="https://docs.symbiota.org/Collection_Manager_Guide/Importing_Uploading/linked_resources" target="_blank"><?= $LANG['ASSOCIATIONS'] ?></a></li>
+				<?php if ($IS_ADMIN) echo '<li><a href="https://docs.symbiota.org/Portal_Manager_Guide/importing_determinations" target="_blank">' . $LANG['DETERMINATIONS'] . '</a></li>'; ?>
+				<li><a href="https://docs.symbiota.org/Collection_Manager_Guide/Images/media_upload_url" target="_blank"><?= $LANG['IMAGE_URLS'] ?></a></li>
+			</ul>
+		</div>
+		<?php
+		if (!$isEditor) {
+			echo '<h2>' . $LANG['ERR_NOT_AUTH'] . '</h2>';
+		} else {
+			$actionStatus = false;
+			if ($action == 'importData') {
+		?>
+				<fieldset>
+					<legend><?= $LANG['ACTION_PANEL'] ?></legend>
+					<?php
+					$importManager->setCreateNewRecord($createNew);
+					echo '<ul>';
+					echo '<li>' . $LANG['STARTING_PROCESS'] . ' ' . $fileName . ' (' . date('Y-m-d H:i:s') . ')</li>';
+					if ($importManager->loadData($_POST)) {
+						echo '<li>' . $LANG['DONE_PROCESSING'] . ' (' . date('Y-m-d H:i:s') . ')</li>';
+					}
+					echo '</ul>';
+					?>
+				</fieldset>
+				<?php
+			} elseif ($action == 'initiateImport') {
+				if ($actionStatus = $importManager->importFile()) {
+					$importManager->setTargetFieldArr($associationType);
+				?>
+					<form name="mappingform" action="neoneditor.php" method="post" onsubmit="return validateMappingForm(this)">
+						<fieldset>
+							<legend><b><?= $LANG['FIELD_MAPPING'] ?></b></legend>
+							<?php
+							if ($associationType) {
+							?>
+								<div class="formField-div">
+									<label for="associationType"><?= $LANG['ASSOCIATION_TYPE'] ?>:</label> <?= $associationType ?>
+									<input name="associationType" type="hidden" value="<?= $associationType ?>">
+								</div>
+							<?php
+							}
+							if ($importType == 1) {
+							?>
+								<div class="formField-div">
+									<label><?= $LANG['RELATIONSHIP'] ?>:</label>
+									<select name="relationship">
+										<option value="">-------------------</option>
+										<?php
+										$filter = '';
+										//if($associationType == 'resource') $filter = 'associationType:resource';
+										$relationshipArr = $importManager->getControlledVocabulary('omoccurassociations', 'relationship', $filter);
+										foreach ($relationshipArr as $term => $display) {
+											echo '<option value="' . $term . '">' . $display . '</option>';
+										}
+										?>
+										<option value="">-------------------</option>
+										<option value="DELETE"><?= $LANG['BATCH_DELETE'] ?></option>
+									</select>
+								</div>
+								<div class="formField-div">
+									<label><?= $LANG['REL_SUBTYPE'] ?>:</label>
+									<select name="subType">
+										<option value="">-------------------</option>
+										<?php
+										$relationshipArr = $importManager->getControlledVocabulary('omoccurassociations', 'subtype');
+										foreach ($relationshipArr as $term => $display) {
+											echo '<option value="' . $term . '">' . $display . '</option>';
+										}
+										?>
+									</select>
+								</div>
+							<?php
+							}
+							?>
+							<div class="formField-div">
+								<?php
+								echo $importManager->getFieldMappingTable();
+								?>
+							</div>
+							<?php
+							if ($importType == 3) {
+							?>
+								<div class="formField-div">
+									<input name="createNew" type="checkbox" value="1" <?= ($createNew ? 'checked' : '') ?>>
+									<label for="createNew"><?= $LANG['NEW_BLANK_RECORD'] ?></label>
+								</div>
+								<div class="formField-div">
+									<label for="mediaUploadType"><?= $LANG['MEDIA_UPLOAD_TYPE'] ?>:</label>
+									<select id="mediaUploadType" name="mediaUploadType" required >
+										<option value="image"><?= $LANG['IMAGE_UPLOAD'] ?></option>
+										<option value="audio"><?= $LANG['AUDIO_UPLOAD'] ?></option>
+									</select>
+								</div>
+							<?php
+							} elseif ($importType == 1) {
+							?>
+								<div class="formField-div">
+									<input name="replace" type="checkbox" value="1">
+									<label for="replace"><?= $LANG['MATCHING_IDENTIFIERS'] ?></label>
+								</div>
+							<?php
+							}
+							if ($importType == 5) {
+							?>
+								<div class="formField-div">
+									<label for='action'><?= $LANG['ACTION'] ?>:</label>
+									<select name="action" id='action'>
+										<option value="add-or-update"><?= $LANG['BATCH_ADD_OR_UPDATE'] ?></option>
+										<option value="delete"><?= $LANG['BATCH_DELETE'] ?></option>
+									</select>
+								</div>
+								<div class="formField-div">
+									<input name="replace-identifier" type="checkbox" value="1">
+									<label for="replace-identifier"><?= $LANG['IDENTIFIER_UPDATE_OR_DELETE'] ?></label>
+								</div>
+							<?php
+							}
+							if ($importType == 6) {
+							?>
+								<div class="formField-div">
+									<label for='action'><?= $LANG['ACTION'] ?>:</label>
+									<select name="action" id='action'>
+										<option value="add"><?= 'Batch add data to empty fields' ?></option>
+										<option value="update"><?= 'Batch update data' ?></option>
+									</select>
+								</div>
+								<div class="formField-div">
+									<input name="prevent-overwrite" type="checkbox" value="1">
+									<label for="allow-overwrite"><?= 'Allow additions or edits to be overwritten during reharvest' ?></label>
+								</div>
+							<?php
+							}
+							?>
+							<div style="margin:15px;">
+								<input name="importType" type="hidden" value="<?= $importType ?>">
+								<input name="fileName" type="hidden" value="<?= htmlspecialchars($importManager->getFileName(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) ?>">
+								<button name="submitAction" type="submit" value="importData"><?= $LANG['IMPORT_DATA'] ?></button>
+							</div>
+						</fieldset>
+					</form>
+				<?php
+				} else echo $LANG['ERR_SETTING_IMPORT'] . ': ' . $importManager->getErrorMessage();
+			}
+			if (!$actionStatus) {
+				?>
+				<form name="initiateImportForm" action="neoneditor.php" method="post" enctype="multipart/form-data" onsubmit="return validateInitiateForm(this)">
+					<fieldset>
+						<legend><?= $LANG['INITIALIZE_IMPORT'] ?></legend>
+						<div class="formField-div">
+							<input name="importFile" type="file" onchange="verifyFileSize(this)" aria-label="<?php echo $LANG['CHOOSE_FILE'] ?>" />
+						</div>
+						<div class="formField-div">
+							<label for="importType"><?= $LANG['IMPORT_TYPE'] ?>: </label>
+							<select id="importType" name="importType" onchange="importTypeChanged(this)" aria-label="<?php echo $LANG['IMPORT_TYPE'] ?>">
+								<option value="">-------------------</option>
+								<option value="1"><?= $LANG['ASSOCIATIONS'] ?></option>
+								<?php if ($IS_ADMIN) {
+									echo '<option value="2">' . $LANG['DETERMINATIONS'] . '</option>';
+								}
+								?>
+								<option value="3"><?= $LANG['IMAGE_FIELD_MAP'] ?></option>
+								<?php
+									echo '<option value="4">' . $LANG['MATERIAL_SAMPLE'] . '</option>';
+								?>
+								<option value="5"><?= $LANG['IDENTIFIERS'] ?></option>
+								<option value="6"><?= 'Occurrence' ?></opetion>
+
+							</select>
+						</div>
+						<div id="associationType-div" class="formField-div" style="display:none">
+							<label for="associationType"><?= $LANG['ASSOCIATION_TYPE'] ?>: </label>
+							<select id="associationType" name="associationType" aria-label="<?php echo $LANG['ASSOCIATION_TYPE'] ?>">
+								<option value="">-------------------</option>
+								<option value="resource"><?= $LANG['RESOURCE_LINK'] ?></option>
+								<option value="internalOccurrence"><?= $LANG['INTERNAL_OCCURRENCE'] ?></option>
+								<option value="externalOccurrence"><?= $LANG['EXTERNAL_OCCURRENCE'] ?></option>
+								<option value="observational"><?= $LANG['OBSERVATION'] ?></option>
+							</select>
+						</div>
+						<div class="formField-div">
+							<input name="MAX_FILE_SIZE" type="hidden" value="10000000" />
+							<button name="submitAction" type="submit" value="initiateImport"><?= $LANG['INITIALIZE_IMPORT'] ?></button>
+						</div>
+					</fieldset>
+				</form>
+		<?php
+			}
+		}
+		?>
+	</div>
+	<?php
+	include($SERVER_ROOT . '/includes/footer.php');
+	?>
+</body>
+
+</html>

--- a/neon/editor/neoneditor.php
+++ b/neon/editor/neoneditor.php
@@ -114,7 +114,6 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 					if (value == "identifiername") {
 						identifierNameIsMapped = true;
 					}
-
 					if (value == 'identifiervalue') {
 						identifierValueIsMapped = true;
 					}
@@ -356,6 +355,17 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 								</div>
 							<?php
 							}
+							if ($importType == 7) {
+							?>
+								<div class="formField-div">
+									<label for='action'><?= $LANG['ACTION'] ?>:</label>
+									<select name="action" id='action'>
+										<option value="add"><?= 'Batch add links' ?></option>
+										<option value="update"><?= 'Batch update links' ?></option>
+									</select>
+								</div>
+							<?php
+							}
 							?>
 							<div style="margin:15px;">
 								<input name="importType" type="hidden" value="<?= $importType ?>">
@@ -390,8 +400,8 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 									echo '<option value="4">' . $LANG['MATERIAL_SAMPLE'] . '</option>';
 								?>
 								<option value="5"><?= $LANG['IDENTIFIERS'] ?></option>
-								<option value="6"><?= 'Occurrence' ?></opetion>
-
+								<option value="6"><?= 'Occurrence' ?></option>
+								<option value="7"><?= 'Genetic' ?></option>
 							</select>
 						</div>
 						<div id="associationType-div" class="formField-div" style="display:none">

--- a/neon/index.php
+++ b/neon/index.php
@@ -55,7 +55,7 @@ if($isEditor){
 				if($IS_ADMIN){
 					?>
 					<li><a href="igsncontrol.php">NEON IGSN Control Panel</a></li>
-					<li><a href="editor/neoneditor.php">Occurrence Editor</a></li>
+					<li><a href="editor/neoneditor.php">NEON Occurrence and Extended Data Editor</a></li>
 					<?php
 				}
 				?>

--- a/neon/index.php
+++ b/neon/index.php
@@ -55,6 +55,7 @@ if($isEditor){
 				if($IS_ADMIN){
 					?>
 					<li><a href="igsncontrol.php">NEON IGSN Control Panel</a></li>
+					<li><a href="editor/neoneditor.php">Occurrence Editor</a></li>
 					<?php
 				}
 				?>


### PR DESCRIPTION
This would simplify several data management workflows and open up possibilities for users without backend access to make a variety of edits much more efficiently. Essentially, this is built off of the existing Symbiota extended data import tools but (1) is not collection specific or limited, (2) essentially allows for skeletal file-ish editing of occurrence records + recording those edits across collections and (3) adds the ability to add/update genetic records.