### PR TITLE
no json_encode dynamicProperties

### DIFF
--- a/classes/DwcArchiverCore.php
+++ b/classes/DwcArchiverCore.php
@@ -1855,9 +1855,9 @@ class DwcArchiverCore extends Manager{
 				if ($rankStr = $dwcOccurManager->getTaxonRank($r['rankid'])) $r['t_taxonRank'] = $rankStr;
 				unset($r['rankid']);
 
-				if(isset($r['dynamicProperties'])) {
-					$r['dynamicProperties'] = json_encode($r['dynamicProperties']);
-				}
+				// if(isset($r['dynamicProperties'])) {
+				// 	$r['dynamicProperties'] = json_encode($r['dynamicProperties']);
+				// }
 				$this->encodeArr($r);
 				$this->addcslashesArr($r);
 				$this->writeOutRecord($fh, $r);


### PR DESCRIPTION
Prevents addition of unnecessary quotes to strings and addition of slashes to fields already json formatted in occurrence download