### PR TITLE
Neon editor additions

### DIFF
--- a/classes/OmMaterialSample.php
+++ b/classes/OmMaterialSample.php
@@ -44,10 +44,15 @@ class OmMaterialSample{
 	public function insertMaterialSample($inputArr){
 		$status = false;
 		if($this->occid && $this->conn){
+			// START NEON Customization
+			$newUuid = UuidFactory::getUuidV4();
 			$sql = 'INSERT INTO ommaterialsample(occid, recordID';
 			$sqlValues = '?, ?, ';
-			$paramArr = array($this->occid);
-			$paramArr[] = UuidFactory::getUuidV4();
+			$paramArr = array($this->occid,$newUuid);
+			// End NEON Customization
+			if(empty($inputArr['guid'])){
+				$inputArr['guid'] = $newUuid;
+			}
 			$this->typeStr = 'is';
 			$this->setParameterArr($inputArr);
 			foreach($this->parameterArr as $fieldName => $value){

--- a/classes/OmMaterialSample.php
+++ b/classes/OmMaterialSample.php
@@ -176,5 +176,47 @@ class OmMaterialSample{
 	public function getErrorMessage(){
 		return $this->errorMessage;
 	}
+
+	// START NEON specific functions
+
+	public function getMatSampleIdByOccidAndCatalogNumber($occid, $catalogNumber) {
+		$occid = intval($occid);
+		$catalogNumber = $this->conn->real_escape_string($catalogNumber);
+
+		$sql = 'SELECT matSampleID 
+				FROM ommaterialsample 
+				WHERE occid = ' . $occid . ' 
+				AND catalogNumber = "' . $catalogNumber . '" 
+				LIMIT 1';
+
+		if ($rs = $this->conn->query($sql)) {
+			if ($row = $rs->fetch_assoc()) {
+				return $row['matSampleID'];
+			}
+		}
+		return null;
+	}
+
+	public function getMatSampleIdByCatalogNumber($catalogNumber){
+		$sql = 'SELECT occid 
+				FROM ommaterialsample 
+				WHERE catalogNumber = ? 
+				LIMIT 1';
+
+		$stmt = $this->conn->prepare($sql);
+		$stmt->bind_param('s', $catalogNumber);
+		$stmt->execute();
+		$stmt->bind_result($occid);
+
+		if($stmt->fetch()){
+			return $occid;
+		}
+
+		return false;
+	}
+
+	// END NEON specific Function
+
+
 }
 ?>

--- a/neon/classes/NeonEditor.php
+++ b/neon/classes/NeonEditor.php
@@ -268,7 +268,6 @@ class NeonEditor extends UtilitiesFileImport {
 			}
 		} elseif ($this->importType == self::IMPORT_MATERIAL_SAMPLE) {
 			if (!in_array('ms_catalognumber', array_map('strtolower', array_keys($this->fieldMap)))) {
-				echo '<script>alert("ERROR: You must map the material sample catalogNumber (ms_catalogNumber) before importing.");</script>';
 				$this->logOrEcho('ERROR: ms_catalogNumber is not mapped in the import field map.', 1);
 				return;
 			}
@@ -288,25 +287,40 @@ class NeonEditor extends UtilitiesFileImport {
 				 	$msArr['catalogNumber'] = $msArr['ms_catalogNumber'];
 				 	unset($msArr['ms_catalogNumber']);
 				}
-				$existingSamples = $importManager->getMaterialSampleArr();
-				$alreadyExists = false;
-				foreach ($existingSamples as $sample) {
-					if ($sample['catalogNumber'] === $msArr['catalogNumber']) {
-						$alreadyExists = true;
-						break;
-					}
-				}
 
-				if ($alreadyExists) {
-					$this->logOrEcho('SKIPPED: Material Sample with catalogNumber "' . $msArr['catalogNumber'] . '" already exists for occid ' . $occid, 1);
-					continue; 
-				}
-				if ($importManager->insertMaterialSample($msArr)) {
-					$this->logOrEcho($LANG['MAT_SAMPLE_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
-                    $status = true;
-				} else {
-					$this->logOrEcho('ERROR loading Material Sample: ' . $importManager->getErrorMessage(), 1);
-				}
+				if ($postArr['action'] === 'add') {
+					$existingoccid = $importManager->getMatSampleIdByCatalogNumber($msArr['catalogNumber']);
+					if ($existingoccid) {
+						$this->logOrEcho('SKIPPED: Material Sample with catalogNumber "' . $msArr['catalogNumber'] .
+							'" already exists for <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $existingoccid . '" target="_blank">' . $existingoccid . '</a>', 1);
+					} elseif ($importManager->insertMaterialSample($msArr)) {
+						$this->logOrEcho($LANG['MAT_SAMPLE_ADDED'] . ': <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+						$status = true;
+					} else {
+						$this->logOrEcho('ERROR loading Material Sample: ' . $importManager->getErrorMessage(), 1);
+					}
+				} elseif ($postArr['action'] === 'update') {
+						$matSampleID = $importManager->getMatSampleIdByOccidAndCatalogNumber($occid, $msArr['catalogNumber']);
+
+						if (!$matSampleID) {
+							$this->logOrEcho(
+								'SKIPPED: No existing material sample found for occid ' . 
+								$occid . ' with catalogNumber "' . $msArr['catalogNumber'] . '"',
+								1
+							);
+							continue;
+						}
+
+						$importManager->setMatSampleID($matSampleID);
+
+						if ($importManager->updateMaterialSample($msArr)) {
+							$this->logOrEcho(
+								'Material sample updated: <a href="' . $GLOBALS['CLIENT_ROOT'] . '/collections/editor/occurrenceeditor.php?occid=' . $occid . '" target="_blank">' . $occid . '</a>', 1);
+							$status = true;
+						} else {
+							$this->logOrEcho('ERROR updating Material Sample: ' . $importManager->getErrorMessage(), 1);
+						}
+					}
 			}
 		} elseif ($this->importType == self::IMPORT_IDENTIFIERS) {
 			$importManager = new OmIdentifiers($this->conn);

--- a/neon/editor/neoneditor.php
+++ b/neon/editor/neoneditor.php
@@ -328,6 +328,17 @@ if ($IS_ADMIN || array_key_exists('SuperAdmin', $USER_RIGHTS)) {
 								</div>
 							<?php
 							}
+							if ($importType == 4){
+							?>
+								<div class="formField-div">
+									<label for='action'><?= $LANG['ACTION'] ?>:</label>
+									<select name="action" id='action'>
+										<option value="add"><?= 'Batch add material samples' ?></option>
+										<option value="update"><?= 'Batch update material samples' ?></option>
+									</select>
+								</div>
+							<?php
+							} 
 							if ($importType == 5) {
 							?>
 								<div class="formField-div">


### PR DESCRIPTION
-Resumes guid assignment for dwc archive mapping to materialSampleID
-Allows ability to update material samples rather than only add them through batch form
-Simplifies logic for preventing duplicate material samples in batch upload