### PR TITLE
allows searching on all material sample identifiers

### DIFF
--- a/classes/OccurrenceManager.php
+++ b/classes/OccurrenceManager.php
@@ -457,7 +457,7 @@ class OccurrenceManager extends OccurrenceTaxaManager {
 
 				// NEON customization - addition
 				if($includeMaterialSample){
-					$matSampleFrag[] = '(catalogNumber IN("'.implode('","',$inFrag).'"))';
+					$matSampleFrag[] = '(catalogNumber IN("'.implode('","',$inFrag).'") OR guid IN("'.implode('","',$inFrag).'") OR matSampleID IN("'.implode('","',$inFrag).'") OR recordID IN("'.implode('","',$inFrag).'") )';
 				}
 				// End of NEON customization
 

--- a/neon/search/index.php
+++ b/neon/search/index.php
@@ -208,7 +208,7 @@ $siteData = new DatasetsMetadata();
 								</div>
 								<div>
 									<input type="checkbox" name="includematerialsample" id="includematerialsample" value=1 data-chip="Include material sample IDs" >
-									<label for="includematerialsample">Include material sample catalog numbers</label>
+									<label for="includematerialsample">Include material sample identifiers</label>
 								</div>
 								<div class="text-area-container">
 									<label for="" class="text-area--outlined">


### PR DESCRIPTION
previously only allowed search on material sample catalogNumber which provided null results when attempting to use guid, recordID, or matSampleID