### PR TITLE
internal vs receipt remarks fields

### DIFF
--- a/neon/classes/ShipmentManager.php
+++ b/neon/classes/ShipmentManager.php
@@ -712,7 +712,7 @@ class ShipmentManager{
 			//Update target record
 			$sql = 'UPDATE NeonSample
 				SET sampleID = ?, alternativeSampleID = ?, sampleCode = ?, sampleClass = ?, sampleUuid = ?,quarantineStatus = ?, namedLocation = ?, collectDate = ?, taxonID = ?,
-				individualCount = ?, filterVolume = ?, domainRemarks = ?, notes = ? WHERE (samplepk = ?)';
+				individualCount = ?, filterVolume = ?, domainRemarks = ?, notes = ?, checkinRemarks = ? WHERE (samplepk = ?)';
 			$stmt = $this->conn->stmt_init();
 			$stmt->prepare($sql);
 			if($stmt->error==null) {
@@ -726,8 +726,9 @@ class ShipmentManager{
 				$filterVol = isset($postArr['filtervolume'])&&$postArr['filtervolume']?$postArr['filtervolume']:NULL;
 				$domainRemarks = isset($postArr['domainremarks'])&&$postArr['domainremarks']?$postArr['domainremarks']:NULL;
 				$sampleNotes = isset($postArr['samplenotes'])&&$postArr['samplenotes']?$postArr['samplenotes']:NULL;
-				$stmt->bind_param('sssssssssiissi', $sampleID, $altID, $sampleCode, $sampleClass, $sampleUuid, $quarStatus, $namedLoc, $collDate, $taxonID,
-					$indCnt, $filterVol, $domainRemarks, $sampleNotes, $postArr['samplepk']);
+				$checkinRemarks = isset($postArr['checkinremarks'])&&$postArr['checkinremarks']?$postArr['checkinremarks']:NULL;
+				$stmt->bind_param('sssssssssiisssi', $sampleID, $altID, $sampleCode, $sampleClass, $sampleUuid, $quarStatus, $namedLoc, $collDate, $taxonID,
+					$indCnt, $filterVol, $domainRemarks, $sampleNotes, $checkinRemarks, $postArr['samplepk']);
 				$stmt->execute();
 				if($stmt->error==null) $status = true;
 				else{

--- a/neon/shipment/sampleeditor.php
+++ b/neon/shipment/sampleeditor.php
@@ -149,7 +149,7 @@ if($isEditor){
 						// });
 					}
 					else if(resJson.code == 2){
-						alert("Is this sampleClass valid? Unable to locate within collection's table");
+						alert("Is this sampleClass valid? Unable to locate within collections table");
 					}
 				});
 			}
@@ -250,7 +250,12 @@ if($isEditor){
 				</div>
 				<div class="fieldGroupDiv">
 					<div class="fieldDiv">
-						<b>Notes:</b> <input name="sampleNotes" type="text" value="<?php echo isset($sampleArr['sampleNotes'])?$sampleArr['sampleNotes']:''; ?>" style="width:500px" />
+						<b>Internal Notes:</b> <input name="sampleNotes" type="text" value="<?php echo isset($sampleArr['sampleNotes'])?$sampleArr['sampleNotes']:''; ?>" style="width:500px" />
+					</div>
+				</div>
+				<div class="fieldGroupDiv">
+					<div class="fieldDiv">
+						<b>Remarks for Receipt:</b> <input name="checkinRemarks" type="text" value="<?php echo isset($sampleArr['checkinRemarks'])?$sampleArr['checkinRemarks']:''; ?>" style="width:500px" />
 					</div>
 				</div>
 				<div style="clear:both;margin:15px">


### PR DESCRIPTION
These changes make it explicit which notes/remarks fields in the manifest module correspond to internal only notes vs. remarks that are exported to submitted receipts.

This also adds the checkinRemarks to the sample editor in order to allow easier sample-by-sample editing of the remarks that affect receipts.