### PR TITLE
Removed unnecessary head call causing jquery load issues

### DIFF
--- a/ident/admin/taxonomylinkage.php
+++ b/ident/admin/taxonomylinkage.php
@@ -16,9 +16,7 @@ $tLinks = $keyManager->getTaxonRelevance();
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=<?php echo $CHARSET;?>">
 	<link href="<?php echo $CSS_BASE_PATH; ?>/jquery-ui.css" type="text/css" rel="stylesheet">
-	<?php
-	include_once($SERVER_ROOT.'/includes/head.php');
-	?>
+
 	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-3.7.1.min.js" type="text/javascript"></script>
 	<script src="<?php echo $CLIENT_ROOT; ?>/js/jquery-ui.min.js" type="text/javascript"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
Documenting this because there might be another case of this down the line.

This page is a tab that is loaded into the parent page via AJAX. Because it contained a included_once(head.php), it was loading in both the jquery used for the react code and then another instance of jquery and jquery-ui (which contains functions needed in this tab), causing the jquery-ui functions to break. 

I have no idea why this isn't the case for the parent page, which does the exact same thing, just the tab. I'm assuming it has to do with the way it's injected into the code vs initial loading. 