### PR TITLE
Add AI cleaning mode for image file names

### DIFF
--- a/classes/ImageLocalProcessor.php
+++ b/classes/ImageLocalProcessor.php
@@ -884,47 +884,86 @@ class ImageLocalProcessor {
 		imagedestroy($tmpImg);
 		return $status;
 	}
-
+	
+	//neon edit
 	/**
-	 * Extract a primary key (catalog number) from a string (e.g file name, catalogNumber field),
-	 * applying patternMatchingTerm, and, if they apply, patternReplacingTerm, and
-	 * replacement.  If patternMatchingTerm contains a backreference,
-	 * and there is a match, the return value is the backreference.  If
-	 * patternReplacingTerm and replacement are modified, they are applied
-	 * before the result is returned.
+	 * Extract a primary key (catalog number) from a string (e.g. file name, catalogNumber field).
+	 *
+	 * Behavior depends on the configured cleaning mode:
+	 *
+	 * - Regex mode:
+	 *   Applies patternMatchingTerm to extract the identifier. If a capture group
+	 *   is present and matches, that value is used. If patternReplacingTerm and
+	 *   replacement are defined, they are applied to the extracted value before
+	 *   returning.
+	 *
+	 * - AI mode:
+	 *   Sends the input string to an AI-based cleaner, optionally guided by an
+	 *   example identifier. The AI returns a cleaned identifier, which is used
+	 *   directly.
 	 *
 	 * param: str  String from which to extract the catalogNumber
-	 * return: an empty string if there is no match of patternMatchingTerm on
-	 *		str, otherwise the match as described above.
+	 * return: the extracted/cleaned identifier, or an empty string if extraction fails
 	 */
 	private function getPrimaryKey($str){
 		$specPk = '';
-		if(isset($this->collArr[$this->activeCollid]['pmterm'])){
-			$pmTerm = $this->collArr[$this->activeCollid]['pmterm'];
-			if(substr($pmTerm,0,1) != '/' || stripos(substr($pmTerm,-3),'/') === false){
-				$this->errorMessage = 'Regular Expression term illegal due to missing forward slashes delimiting the term: '.$pmTerm;
-				$this->logOrEcho('PROCESS ABORTED: '.$this->errorMessage,1);
-				exit('ABORT: '.$this->errorMessage);
+	
+		$mode = $this->collArr[$this->activeCollid]['cleaningmode'] ?? 'regex';
+	
+		if($mode === 'ai'){
+			$example = $this->collArr[$this->activeCollid]['aiexampleidentifiers'] ?? '';
+			$extra = $this->collArr[$this->activeCollid]['aiextrainstructions'] ?? '';
+			
+			$specPk = $this->cleanWithAI($str, $example, $extra);
+	
+			if(!$specPk){
+				$this->logOrEcho('AI failed to extract identifier from: '.$str, 1);
+				return '';
 			}
-			if(!strpos($pmTerm,'(') || !strpos($pmTerm,')')){
-				$this->errorMessage = 'Regular Expression term illegal due to missing capture term: '.$pmTerm;
-				$this->logOrEcho('PROCESS ABORTED: '.$this->errorMessage,1);
-				exit('ABORT: '.$this->errorMessage);
-			}
-			if(preg_match($pmTerm,$str,$matchArr)){
-				if(array_key_exists(1,$matchArr) && $matchArr[1]){
-					$specPk = $matchArr[1];
+			
+			$this->logOrEcho('AI cleaned identifier: "'.$str.'" => "'.$specPk.'"', 1);
+	
+			return $specPk;
+		} elseif($mode === 'regex') {
+	
+			if(isset($this->collArr[$this->activeCollid]['pmterm'])){
+				$pmTerm = $this->collArr[$this->activeCollid]['pmterm'];
+		
+				if(substr($pmTerm,0,1) != '/' || stripos(substr($pmTerm,-3),'/') === false){
+					$this->errorMessage = 'Regular Expression term illegal due to missing forward slashes delimiting the term: '.$pmTerm;
+					$this->logOrEcho('PROCESS ABORTED: '.$this->errorMessage,1);
+					exit('ABORT: '.$this->errorMessage);
 				}
-				if(isset($this->collArr[$this->activeCollid]['prpatt'])) {
-					$specPk = preg_replace($this->collArr[$this->activeCollid]['prpatt'],$this->collArr[$this->activeCollid]['prrepl'],$specPk);
+		
+				if(!strpos($pmTerm,'(') || !strpos($pmTerm,')')){
+					$this->errorMessage = 'Regular Expression term illegal due to missing capture term: '.$pmTerm;
+					$this->logOrEcho('PROCESS ABORTED: '.$this->errorMessage,1);
+					exit('ABORT: '.$this->errorMessage);
 				}
-				if(isset($matchArr[2])){
-					$this->medSourceSuffix = $matchArr[2];
+		
+				if(preg_match($pmTerm,$str,$matchArr)){
+					if(array_key_exists(1,$matchArr) && $matchArr[1]){
+						$specPk = $matchArr[1];
+					}
+		
+					if(isset($this->collArr[$this->activeCollid]['prpatt'])) {
+						$specPk = preg_replace(
+							$this->collArr[$this->activeCollid]['prpatt'],
+							$this->collArr[$this->activeCollid]['prrepl'],
+							$specPk
+						);
+					}
+		
+					if(isset($matchArr[2])){
+						$this->medSourceSuffix = $matchArr[2];
+					}
 				}
 			}
 		}
+	
 		return $specPk;
 	}
+	//end neon edit
 
 	private function getOccid($catalogNumber){
 		$occid = 0;
@@ -1685,6 +1724,75 @@ class ImageLocalProcessor {
 			}
 		}
 	}
+	
+	//neon edit
+	private function cleanWithAI($value, $examplesRaw = '', $extraInstructions = '') {
+	
+		$exampleArr = array_filter(array_map('trim', explode("\n", $examplesRaw)));
+		$exampleList = '"' . implode('", "', $exampleArr) . '"';
+	
+		$prompt = "Extract a cleaned identifier from this filename: \"$value\". Match the structure of these examples: $exampleList.";
+
+		if($extraInstructions){
+			$prompt .= ' ' . trim($extraInstructions);
+		}
+	
+		$prompt .= " Return ONLY the identifier.";
+	
+		$response = $this->callAI($prompt);
+		return trim($response);
+	}
+	
+	private function callAI($prompt) {
+		$apiKey = $GLOBALS['OPENAI_API_KEY'] ?? '';
+		$model = $GLOBALS['OPENAI_MODEL'] ?? 'gpt-4.1-mini';
+
+		if(!$apiKey){
+			$this->logOrEcho('ERROR: OpenAI API key not configured', 1);
+			return '';
+		}
+	
+		$data = [
+			"model" => $model,
+			"messages" => [
+				["role" => "user", "content" => $prompt]
+			]
+		];
+	
+		$ch = curl_init("https://api.openai.com/v1/chat/completions");
+		curl_setopt_array($ch, [
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_HTTPHEADER => [
+				"Authorization: Bearer $apiKey",
+				"Content-Type: application/json"
+			],
+			CURLOPT_POST => true,
+			CURLOPT_POSTFIELDS => json_encode($data)
+		]);
+	
+		$result = curl_exec($ch);
+		curl_close($ch);
+	
+		$json = json_decode($result, true);
+		
+		if(isset($json['error'])){
+			$this->logOrEcho('AI ERROR: '.$json['error']['message'], 1);
+			return '';
+		}
+		
+		if(isset($json['usage'])){
+			$usage = $json['usage'];
+			$this->logOrEcho(
+				'AI TOKENS | prompt: '.$usage['prompt_tokens'].
+				' | completion: '.$usage['completion_tokens'].
+				' | total: '.$usage['total_tokens'],
+				1
+			);
+		}
+
+		return $json['choices'][0]['message']['content'] ?? '';
+	}
+	//end neon edit
 
 	//Misc data functions
 	private function setImageTableMap(){

--- a/classes/SpecProcessorManager.php
+++ b/classes/SpecProcessorManager.php
@@ -32,6 +32,11 @@ class SpecProcessorManager {
 	protected $createLgImg = 2;
 	protected $customStoredProcedure;
 	protected $lastRunDate = '';
+	//neon edit
+	protected $cleaningMode = 'regex';
+	protected $aiExampleIdentifiers = '';
+	protected $aiExtraInstructions = '';
+	//end neon edit
 
 	protected $dbMetadata = 1;			//Only used when run as a standalone script
 	protected $processUsingImageMagick = 0;
@@ -79,7 +84,10 @@ class SpecProcessorManager {
 		if(is_numeric($editArr['spprid'])){
 			$sqlFrag = '';
 			$targetFields = array('title','projecttype','speckeypattern','patternreplace','replacestr','sourcepath','targetpath','imgurl',
-				'webpixwidth','tnpixwidth','lgpixwidth','jpgcompression','createtnimg','createlgimg','source');
+								  //neon edit
+								  'cleaningmode', 'aiExampleIdentifiers', 'aiExtraInstructions',
+								  //end neon edit
+								  'webpixwidth','tnpixwidth','lgpixwidth','jpgcompression','createtnimg','createlgimg','source');
 			if(!isset($editArr['createtnimg'])) $editArr['createtnimg'] = 0;
 			if(!isset($editArr['createlgimg'])) $editArr['createlgimg'] = 0;
 			foreach($editArr as $k => $v){
@@ -122,8 +130,9 @@ class SpecProcessorManager {
 					($sourcePath?'"'.$this->cleanInStr($sourcePath).'"':'NULL').')';
 			}
 			elseif($addArr['projecttype'] == 'local'){
+				//neon edit
 				$sql = 'INSERT INTO specprocessorprojects(collid,title,speckeypattern,patternreplace,replacestr,projecttype,sourcepath,targetpath,'.
-					'imgurl,webpixwidth,tnpixwidth,lgpixwidth,jpgcompression,createtnimg,createlgimg) '.
+					'imgurl,webpixwidth,tnpixwidth,lgpixwidth,jpgcompression,createtnimg,createlgimg,cleaningmode,aiExampleIdentifiers,aiExtraInstructions) '.
 					'VALUES('.$this->collid.',"'.$this->cleanInStr($addArr['title']).'","'.
 					$this->cleanInStr($addArr['speckeypattern']).'",'.
 					($addArr['patternreplace']?'"'.$this->cleanInStr($addArr['patternreplace']).'"':'NULL').','.
@@ -137,7 +146,12 @@ class SpecProcessorManager {
 					(isset($addArr['lgpixwidth'])&&$addArr['lgpixwidth']?$addArr['lgpixwidth']:'NULL').','.
 					(isset($addArr['jpgcompression'])&&$addArr['jpgcompression']?$addArr['jpgcompression']:'NULL').','.
 					(isset($addArr['createtnimg'])&&$addArr['createtnimg']?$addArr['createtnimg']:'NULL').','.
-					(isset($addArr['createlgimg'])&&$addArr['createlgimg']?$addArr['createlgimg']:'NULL').')';
+					//neon edit
+					(isset($addArr['createlgimg'])&&$addArr['createlgimg']?$addArr['createlgimg']:'NULL').','.
+					(isset($addArr['cleaningmode']) && $addArr['cleaningmode'] ? '"'.$this->cleanInStr($addArr['cleaningmode']).'"' : '"regex"').','.
+					(isset($addArr['aiExampleIdentifiers']) && $addArr['aiExampleIdentifiers'] ? '"'.$this->conn->real_escape_string($addArr['aiExampleIdentifiers']).'"' : 'NULL').','.
+					(isset($addArr['aiExtraInstructions']) && $addArr['aiExtraInstructions'] ? '"'.$this->conn->real_escape_string($addArr['aiExtraInstructions']).'"' : 'NULL').')';
+					//end neon edit
 			}
 		}
 		elseif($addArr['title'] == 'OCR Harvest' && $addArr['newprofile']){
@@ -168,6 +182,9 @@ class SpecProcessorManager {
 		}
 		if($sqlWhere){
 			$sql = 'SELECT collid, title, speckeypattern, patternreplace, replacestr, projecttype, coordx1, coordx2, coordy1, coordy2, sourcepath, targetpath, '.
+				//neon edit
+				'cleaningmode, aiExampleIdentifiers, aiExtraInstructions, '.
+				//end neon edit
 				'imgurl, webpixwidth, tnpixwidth, lgpixwidth, jpgcompression, createtnimg, createlgimg, source, lastrundate '.
 				'FROM specprocessorprojects '.$sqlWhere;
 			//echo $sql;
@@ -193,6 +210,11 @@ class SpecProcessorManager {
 				$this->createTnImg = $row->createtnimg;
 				$this->createLgImg = $row->createlgimg;
 				$this->lastRunDate = $row->lastrundate;
+				//neon edit
+				$this->cleaningMode = $row->cleaningmode;
+				$this->aiExampleIdentifiers = $row->aiExampleIdentifiers;
+				$this->aiExtraInstructions = $row->aiExtraInstructions;
+				//end neon edit
 				if(!$this->lastRunDate && $row->source && preg_match('/\d{4}-\d{2}-\d{2}/', $row->source)) $this->lastRunDate = $row->source;
 				if(!$this->projectType){
 					if($this->title == 'iDigBio CSV upload'){
@@ -825,6 +847,34 @@ class SpecProcessorManager {
  	public function getUseImageMagick(){
  		return $this->processUsingImageMagick;
  	}
+	
+	//neon edit
+	public function setCleaningMode($m){
+		if(in_array($m, ['regex','ai'])){
+			$this->cleaningMode = $m;
+		}
+	}
+	
+	public function getCleaningMode(){
+		return $this->cleaningMode ?: 'regex';
+	}
+	
+	public function setAiExampleIdentifiers($str){
+		$this->aiExampleIdentifiers = $str;
+	}
+	
+	public function getAiExampleIdentifiers(){
+		return $this->aiExampleIdentifiers;
+	}
+	
+	public function setAiExtraInstructions($str){
+		$this->aiExtraInstructions = $str;
+	}
+	
+	public function getAiExtraInstructions(){
+		return $this->aiExtraInstructions;
+	}
+	//end neon edit	
 
  	public function getConn(){
  		return $this->conn;

--- a/collections/specprocessor/imageprocessor.php
+++ b/collections/specprocessor/imageprocessor.php
@@ -49,6 +49,9 @@ if($spprid) $specManager->setProjVariables($spprid);
 				}
 
 				uploadTypeChanged();
+				//neon edit
+				cleaningModeChanged();
+				//end neon edit
 			});
 
 			function uploadTypeChanged(){
@@ -59,6 +62,9 @@ if($spprid) $specManager->setProjVariables($spprid);
 					$("#titleDiv").show();
 					$("#sourcePathInfoIplant").hide();
 					$("#chooseFileDiv").hide();
+					//neon edit
+					cleaningModeChanged();
+					//end neon edit
 					if(f.sourcepath.value == "-- Use Default Path --") f.sourcepath.value = "";
 					f.profileEditSubmit.value = "Save Profile";
 					$("#submitDiv").show();
@@ -115,16 +121,22 @@ if($spprid) $specManager->setProjVariables($spprid);
 					}
 				}
 				else{
-					if(f.speckeypattern.value == ""){
-						alert("<?php echo $LANG['NEED_PATTERN_MATCH']; ?>");
-						return false;
-					}
-					if(f.speckeypattern.value.substr(f.speckeypattern.value.length-3).toLowerCase() != "csv"){
-						if(f.speckeypattern.value.indexOf("(") < 0 || f.speckeypattern.value.indexOf(")") < 0){
-							alert("<?php echo $LANG['CATNUM_IN_PARENS']; ?>");
+					//neon edit
+					if(f.cleaningmode.value === 'regex') {
+					
+						if(f.speckeypattern.value == ""){
+							alert("<?php echo $LANG['NEED_PATTERN_MATCH']; ?>");
 							return false;
 						}
+					
+						if(f.speckeypattern.value.substr(f.speckeypattern.value.length-3).toLowerCase() != "csv"){
+							if(f.speckeypattern.value.indexOf("(") < 0 || f.speckeypattern.value.indexOf(")") < 0){
+								alert("<?php echo $LANG['CATNUM_IN_PARENS']; ?>");
+								return false;
+							}
+						}
 					}
+					//end neon edit
 				}
 				if(f.projecttype.value == 'local'){
 					if(!isNumeric(f.webpixwidth.value)){
@@ -202,6 +214,36 @@ if($spprid) $specManager->setProjVariables($spprid);
 				}
 				return true;
 			}
+			//neon edit
+			function cleaningModeChanged() {
+				var mode = document.getElementById('cleaningmode').value;
+				var f = document.getElementById('editproj');
+				var uploadType = f.projecttype.value;
+				
+				if(uploadType === 'local') {
+					if(mode === 'regex') {
+						$("#specKeyPatternDiv").show();
+						$("#patternReplaceDiv").show();
+						$("#replaceStrDiv").show();
+						$("#aiExampleDiv").hide();
+						$("#aiExtraDiv").hide();
+					} else {
+						$("#specKeyPatternDiv").hide();
+						$("#patternReplaceDiv").hide();
+						$("#replaceStrDiv").hide();
+						$("#aiExampleDiv").show();
+						$("#aiExtraDiv").show();
+					}
+				} else {
+					// hide everything if not local
+					$("#specKeyPatternDiv").hide();
+					$("#patternReplaceDiv").hide();
+					$("#replaceStrDiv").hide();
+					$("#aiExampleDiv").hide();
+					$("#aiExtraDiv").hide();
+				}
+			}
+			//end neon edit
 		</script>
 		<style>
 			label { width:220px; float:left; margin-right:3px }
@@ -332,6 +374,31 @@ if($spprid) $specManager->setProjVariables($spprid);
 											<input name="title" type="text" style="width:300px;" value="<?php echo $specManager->getTitle(); ?>" />
 										</div>
 									</div>
+									<!--neon edit-->
+									<div id="cleaningModeDiv" class="profileDiv" style="display:<?php echo ($projectType?'block':'none'); ?>">
+										<label>Cleaning Method:</label>
+										<div style="float:left;">
+											<select name="cleaningmode" id="cleaningmode" onchange="cleaningModeChanged()">
+												<option value="regex" <?php echo ($specManager->getCleaningMode() == 'regex' ? 'SELECTED' : ''); ?>>Regex</option>
+												<option value="ai" <?php echo ($specManager->getCleaningMode() == 'ai' ? 'SELECTED' : ''); ?>>AI</option>
+											</select>
+										</div>
+									</div>
+									<div id="aiExampleDiv" class="profileDiv">
+										<label>Example Identifiers:</label>
+										<div style="float:left;">
+											<textarea name="aiExampleIdentifiers" rows="5" style="width:400px;"
+												placeholder="Enter one example per line"><?php echo htmlspecialchars($specManager->getAiExampleIdentifiers()); ?></textarea>
+										</div>
+									</div>
+									<div id="aiExtraDiv" class="profileDiv">
+										<label>Extra Instructions:</label>
+										<div style="float:left;">
+											<textarea name="aiExtraInstructions" rows="5" style="width:400px;"
+												placeholder="Optional: Additional instructions to include in the AI prompt (e.g., enforce structure or suffix)"><?php echo htmlspecialchars($specManager->getAiExtraInstructions()); ?></textarea>
+										</div>
+									</div>
+									<!--end neon edit-->
 									<div id="specKeyPatternDiv" class="profileDiv" style="display:<?php echo ($projectType?'block':'none'); ?>">
 										<label><?php echo $LANG['PATT_MATCH_TERM']; ?>:</label>
 										<div style="float:left;">
@@ -528,6 +595,9 @@ if($spprid) $specManager->setProjVariables($spprid);
 							?>
 						</div>
 						<?php
+						//neon edit
+						$cleaningMode = $specManager->getCleaningMode() ?: 'regex';
+						//end neon edit
 						if($spprid){
 							?>
 							<div id="imgprocessdiv" style="position:relative;">
@@ -559,36 +629,81 @@ if($spprid) $specManager->setProjVariables($spprid);
 											<?php
 										}
 										?>
-										<div style="margin-top:10px;clear:left;">
-											<label><?php echo $LANG['PATT_MATCH_TERM']; ?>:</label>
-											<div style="float:left;">
-												<?php echo $specManager->getSpecKeyPattern(); ?>
-												<input type='hidden' name='speckeypattern' value='<?php echo $specManager->getSpecKeyPattern();?>' />
-											</div>
-										</div>
-										<div style="clear:both;">
-											<label>Match term on:</label>
-											<div style="float:left;">
-												<input name="matchcatalognumber" type="checkbox" value="1" checked /> <?php echo $LANG['CAT_NUM']; ?>
-												<input name="matchothercatalognumbers" type="checkbox" value="1" style="margin-left:30px;" /> <?php echo $LANG['OTHER_CAT_NUMS']; ?>
-											</div>
-										</div>
+										<!--neon edit-->
 										<div style="margin-top:10px;clear:both;">
-											<label><?php echo $LANG['REPLACEMENT_TERM']; ?>:</label>
-											<div style="float:left;">
-												<?php echo $specManager->getPatternReplace(); ?>
-												<input type='hidden' name='patternreplace' value='<?php echo $specManager->getPatternReplace();?>' />
-											</div>
-										</div>
-										<div style="margin-top:10px;clear:both;">
-											<label><?php echo $LANG['REPLACEMENT_STR']; ?>:</label>
+											<label>Cleaning Mode:</label>
 											<div style="float:left;">
 												<?php
-												echo str_replace(' ', '&lt;space&gt;', $specManager->getReplaceStr());
+													$mode = $specManager->getCleaningMode();
+										
+													if ($mode === 'ai') {
+														echo 'AI';
+													} elseif ($mode === 'regex') {
+														echo 'Regex';
+													} else {
+														echo $mode;
+													}
 												?>
-												<input type='hidden' name='replacestr' value='<?php echo $specManager->getReplaceStr(); ?>' />
 											</div>
 										</div>
+										<?php if($cleaningMode === 'regex'){ ?>
+											<div style="margin-top:10px;clear:left;">
+												<label><?php echo $LANG['PATT_MATCH_TERM']; ?>:</label>
+												<div style="float:left;">
+													<?php echo $specManager->getSpecKeyPattern(); ?>
+													<input type='hidden' name='speckeypattern' value='<?php echo $specManager->getSpecKeyPattern();?>' />
+												</div>
+											</div>
+											<div style="clear:both;">
+												<label>Match term on:</label>
+												<div style="float:left;">
+													<input name="matchcatalognumber" type="checkbox" value="1" checked /> <?php echo $LANG['CAT_NUM']; ?>
+													<input name="matchothercatalognumbers" type="checkbox" value="1" style="margin-left:30px;" /> <?php echo $LANG['OTHER_CAT_NUMS']; ?>
+												</div>
+											</div>
+											<div style="margin-top:10px;clear:both;">
+												<label><?php echo $LANG['REPLACEMENT_TERM']; ?>:</label>
+												<div style="float:left;">
+													<?php echo $specManager->getPatternReplace(); ?>
+													<input type='hidden' name='patternreplace' value='<?php echo $specManager->getPatternReplace();?>' />
+												</div>
+											</div>
+											<div style="margin-top:10px;clear:both;">
+												<label><?php echo $LANG['REPLACEMENT_STR']; ?>:</label>
+												<div style="float:left;">
+													<?php
+													echo str_replace(' ', '&lt;space&gt;', $specManager->getReplaceStr());
+													?>
+													<input type='hidden' name='replacestr' value='<?php echo $specManager->getReplaceStr(); ?>' />
+												</div>
+											</div>
+										<?php } ?>
+										<?php if($cleaningMode === 'ai'){ ?>
+											<div style="clear:both;">
+												<label>Match term on:</label>
+												<div style="float:left;">
+													<input name="matchcatalognumber" type="checkbox" value="1" checked /> <?php echo $LANG['CAT_NUM']; ?>
+													<input name="matchothercatalognumbers" type="checkbox" value="1" style="margin-left:30px;" /> <?php echo $LANG['OTHER_CAT_NUMS']; ?>
+												</div>
+											</div>
+											<div style="margin-top:10px;clear:both;">
+												<label>Example Identifiers:</label>
+												<div style="float:left;">
+													<?php echo nl2br(htmlspecialchars($specManager->getAiExampleIdentifiers())); ?>
+													<input type='hidden' name='aiExampleIdentifiers' 
+													value='<?php echo htmlspecialchars($specManager->getAiExampleIdentifiers(), ENT_QUOTES); ?>' />
+												</div>
+											</div>
+											<div style="margin-top:10px;clear:both;">
+												<label>Extra Instructions:</label>
+												<div style="float:left;">
+													<?php echo nl2br(htmlspecialchars($specManager->getAiExtraInstructions())); ?>
+													<input type='hidden' name='aiExtraInstructions' 
+													value='<?php echo htmlspecialchars($specManager->getAiExtraInstructions(), ENT_QUOTES); ?>' />
+												</div>
+											</div>
+										<?php } ?>
+										<!--end neon edit-->
 										<?php
 										if($projectType != 'idigbio'){
 											?>

--- a/collections/specprocessor/processor.php
+++ b/collections/specprocessor/processor.php
@@ -84,7 +84,18 @@ $statusStr = "";
 						$logFile = $collid.'_'.$specManager->getInstitutionCode();
 						if($specManager->getCollectionCode()) $logFile .= '-'.$specManager->getCollectionCode();
 						$imageProcessor->initProcessor($logFile);
-						$imageProcessor->setCollArr(array($collid => array('pmterm' => $specManager->getSpecKeyPattern(),'prpatt' => $specManager->getPatternReplace(),'prrepl' => $specManager->getReplaceStr())));
+						//neon edit
+						$imageProcessor->setCollArr(array(
+							$collid => array(
+								'pmterm' => $specManager->getSpecKeyPattern(),
+								'prpatt' => $specManager->getPatternReplace(),
+								'prrepl' => $specManager->getReplaceStr(),
+								'cleaningmode' => $specManager->getCleaningMode(),
+								'aiexampleidentifiers' => $specManager->getAiExampleIdentifiers(),
+								'aiextrainstructions' => $specManager->getAiExtraInstructions()
+							)
+						));
+						//end neon edit
 						$imageProcessor->setMatchCatalogNumber((array_key_exists('matchcatalognumber', $_POST)?1:0));
 						$imageProcessor->setMatchOtherCatalogNumbers((array_key_exists('matchothercatalognumbers', $_POST)?1:0));
 						$imageProcessor->setDbMetadata(1);

--- a/neon/config/schema/db_schema_patch-1.5.sql
+++ b/neon/config/schema/db_schema_patch-1.5.sql
@@ -1,0 +1,9 @@
+ALTER TABLE specprocessorprojects
+ADD cleaningmode VARCHAR(10) DEFAULT 'regex'
+AFTER projecttype;
+
+ALTER TABLE specprocessorprojects
+ADD aiExampleIdentifiers TEXT AFTER cleaningmode;
+
+ALTER TABLE specprocessorprojects
+ADD aiExtraInstructions TEXT AFTER aiExampleIdentifiers;


### PR DESCRIPTION
While testing LMA image uploads, it became clear that no single image profile regex was going to reliably clean all filenames. Although most filenames contain a SampleID, they often include inconsistent suffixes, notes, or other extra text. Instead of handling these cases manually, this introduces an OpenAI option that uses example identifiers and instruction text to normalize filenames.

Two variables need to be added to symbini.php:

`$OPENAI_API_KEY = '';`
`$OPENAI_MODEL = 'gpt-5.4'; // https://developers.openai.com/api/docs/pricing`

A SQL patch is also included to add the necessary fields to the database.

For gpt-5.4, each call uses ~150–200 tokens. This works out to roughly ~6k filename calls for $2.50.