### PR TITLE
Add Dev Mode authentication toggle

### DIFF
--- a/checklists/dynamicmap.php
+++ b/checklists/dynamicmap.php
@@ -1,7 +1,7 @@
 <?php
-header("Location: https://biorepo.neonscience.org", true, 302);
-exit;
 include_once('../config/symbini.php');
+header('Location: ../', true, 302);
+exit;
 //include_once($SERVER_ROOT.'/classes/DynamicChecklistManager.php');
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/checklists/dynamicmap.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT . '/content/lang/checklists/dynamicmap.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT.'/content/lang/checklists/dynamicmap.en.php');

--- a/collections/index.php
+++ b/collections/index.php
@@ -1,7 +1,8 @@
 <?php
-header("Location: https://biorepo.neonscience.org/portal/collections/misc/browsecollprofiles.php", true, 302);
-exit;
 include_once('../config/symbini.php');
+header('Location: misc/browsecollprofiles.php', true, 302);
+exit;
+
 include_once($SERVER_ROOT.'/content/lang/collections/sharedterms.'.$LANG_TAG.'.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceManager.php');
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/collections/index.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT.'/content/lang/collections/index.' . $LANG_TAG . '.php');

--- a/collections/misc/collprofiles.php
+++ b/collections/misc/collprofiles.php
@@ -1,16 +1,11 @@
 <?php
+include_once('../../config/symbini.php');
 //neon edit
 // Redirect all collprofiles.php requests to neoncollprofiles.php with the same collid parameter
-if (isset($_GET['collid'])) {
-    $collid = intval($_GET['collid']);
-    header("Location: neoncollprofiles.php?collid=$collid", true, 302);
-    exit;
-}
-header("Location: https://biorepo.neonscience.org/portal/collections/misc/browsecollprofiles.php", true, 302);
+header('Location: neoncollprofiles.php?collid=' . (empty($_REQUEST['collid']) ? '' : $_REQUEST['collid']), true, 302);
 exit;
 //end neon edit
 
-include_once('../../config/symbini.php');
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/collections/misc/collprofiles.' . $LANG_TAG . '.php')) include_once($SERVER_ROOT.'/content/lang/collections/misc/collprofiles.' . $LANG_TAG . '.php');
 else include_once($SERVER_ROOT . '/content/lang/collections/misc/collprofiles.en.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceCollectionProfile.php');

--- a/collections/misc/protectedspecies.php
+++ b/collections/misc/protectedspecies.php
@@ -1,5 +1,5 @@
 <?php
-header("Location: https://biorepo.neonscience.org", true, 302);
+header("Location: ../../", true, 302);
 exit;
 include_once('../../config/symbini.php');
 include_once($SERVER_ROOT.'/classes/OccurrenceProtectedSpecies.php');

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -1,9 +1,7 @@
 <?php
-header("Location: https://biorepo.neonscience.org/portal/neon/search/index.php", true, 302);
-exit;
-// error_reporting(E_ALL);
-// ini_set('display_errors', '1');
 include_once('../../config/symbini.php');
+header("Location: ../../neon/search/index.php", true, 302);
+exit;
 include_once($SERVER_ROOT . '/classes/CollectionMetadata.php');
 include_once($SERVER_ROOT . '/classes/DatasetsMetadata.php');
 include_once($SERVER_ROOT . '/classes/OccurrenceManager.php');

--- a/imagelib/index.php
+++ b/imagelib/index.php
@@ -1,7 +1,8 @@
 <?php
-header("Location: https://biorepo.neonscience.org/portal/neon/search/index.php", true, 302);
-exit;
+header("Location: https://biorepo.neonscience.org/portal", true, 302);
 include_once('../config/symbini.php');
+header('Location: ../neon/search/index.php', true, 302);
+exit;
 include_once($SERVER_ROOT.'/classes/ImageLibraryBrowser.php');
 if($LANG_TAG != 'en' && file_exists($SERVER_ROOT.'/content/lang/imagelib/index.'.$LANG_TAG.'.php')) include_once($SERVER_ROOT.'/content/lang/imagelib/index.'.$LANG_TAG.'.php');
 else include_once($SERVER_ROOT.'/content/lang/imagelib/index.en.php');

--- a/includes/head.php
+++ b/includes/head.php
@@ -293,7 +293,12 @@ elseif (array_key_exists('CollAdmin', $USER_RIGHTS) || array_key_exists('CollEdi
                         myAccountButton.addEventListener('click', () => {
                     EOL;
 
-                    echo "window.location.href = 'https://data.neonscience.org/myaccount';";
+                    if(empty($NEON_DEV_MODE)){
+                    	echo "window.location.href = 'https://data.neonscience.org/myaccount';";
+                    }
+                    else{
+                    	echo "window.location.href = '".$CLIENT_ROOT."/profile/viewprofile.php';";
+                    }
                     echo <<<EOL
                         });
                         const signInDiv = document.getElementById("header__authentication-ui");
@@ -361,7 +366,12 @@ elseif (array_key_exists('CollAdmin', $USER_RIGHTS) || array_key_exists('CollEdi
                         signinButton.addEventListener('click', () => {
                     EOL;
 
-                    echo "window.location.href = '".$CLIENT_ROOT."/profile/openIdAuth.php';";
+                    if(empty($NEON_DEV_MODE)){
+                    	echo "window.location.href = '".$CLIENT_ROOT."/profile/openIdAuth.php';";
+                    }
+                    else{
+                    	echo "window.location.href = '".$CLIENT_ROOT."/profile/index.php';";
+                    }
                     echo <<<EOL
                         });
                         const signInDiv = document.getElementById("header__authentication-ui");

--- a/includes/usagepolicy.php
+++ b/includes/usagepolicy.php
@@ -1,5 +1,5 @@
 <?php
-header("Location: https://biorepo.neonscience.org/portal/misc/cite.php", true, 302);
+header("Location: ../misc/cite.php", true, 302);
 exit;
 include_once('../config/symbini.php');
 header("Content-Type: text/html; charset=" . $CHARSET);

--- a/index.php
+++ b/index.php
@@ -1,9 +1,9 @@
 <?php
-header("Location: https://www.neonscience.org/samples", true, 302);
-exit;
-//error_reporting(E_ALL);
-//ini_set('display_errors', '1');
 include_once('config/symbini.php');
+if(empty($NEON_DEV_MODE)){
+	header("Location: https://www.neonscience.org/samples", true, 302);
+	exit;
+}
 include_once('content/lang/index.' . $LANG_TAG . '.php');
 include_once($SERVER_ROOT . '/neon/classes/PortalStatistics.php');
 header('Cache-Control: no-cache');
@@ -32,10 +32,10 @@ $statsArr = json_encode($stats->getBlueNeonStats());
 <script type="module">
 	// countup animation
 	import { CountUp } from './neon/js/countUp.min.js';
-	
+
 	window.onload = function() {
 		var data = <?php echo $statsArr; ?>;
-	
+
 		// Array of target elements
 		var targets = [
 		  { id: 'speciesCount', value: data.noSpecies, suffix: ' species' },
@@ -45,7 +45,7 @@ $statsArr = json_encode($stats->getBlueNeonStats());
 		  { id: 'sampleTypeCount', value: data.noSampleTypes, suffix: ' sample types' },
 		  { id: 'siteCount', value: data.noSites, suffix: ' sites' },
 		];
-	
+
 		// Iterate over the targets array and initialize CountUp for each element
 		targets.forEach(function(target) {
 		  var countUp = new CountUp(target.id, target.value, { enableScrollSpy: true, suffix: target.suffix, duration: 3 });

--- a/misc/cite.php
+++ b/misc/cite.php
@@ -10,15 +10,15 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 	include_once($SERVER_ROOT . '/includes/head.php');
 	?>
 	<style>
-		
+
 		h1 {
 			font-size: 2.5rem !important;
 		}
-		
+
 		h4 {
 			font-size: 1.1rem !important;
 		}
-		
+
 		.anchor {
 			font-size: 1.675rem !important;
 			scroll-margin-top: 150px;
@@ -53,7 +53,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 	<div id="innertext">
 		<h1>Acknowledging and Citing the NEON Biorepository</h1>
-		
+
 		<article>
 			<h3 class="anchor" id="h.1">Acknowledgement</h3>
 			<p>Any publications involving use of NEON samples and specimens should include the following acknowledgment:</p>
@@ -77,20 +77,20 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 			<h3 class="anchor" id="h.3">Citation Requirements for Data-Only Use</h3>
 
 			<p>NEON sample data is offered under the Creative Commons Attribution (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>) license. Attribution is required when you use NEON data, including a link to the license and an indication of any changes.</p>
-			
+
 			<p>Records in the <a href="../neon/search/index.php" target="_blank" rel="noopener noreferrer">NEON Biorepository Sample Portal</a> are periodically updated based on ingestion of the most up-to-date NEON data and are, in many cases, supplemented with value-added data obtained from further analysis. Because these records are updated on a rolling basis and are not tied to a specific NEON data release, NEON Biorepository sample data should be considered subject to change and <strong>treated as provisional</strong>. Citations of these data should therefore follow <a href="https://www.neonscience.org/data-samples/guidelines-policies/citing#citing-data" target="_blank" rel="noopener noreferrer">NEON guidance for provisional data</a>, applied to the relevant Biorepository sample types.</p>
 
 			<p><b>Due to the live management of sample data, it is recommended that data for each sample type used in analyses be saved to an external repository for reproducibility, assigned a DOI, and cited as follows:</b></p>
 			<blockquote>
 				NEON (National Ecological Observatory Network) Biorepository. Mammal Collection (Ear Tissue). Data accessed from
-				<a href="https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25" target="_blank" rel="noopener noreferrer">https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25</a>
+				<a href="../collections/misc/neoncollprofiles.php?collid=25" target="_blank" rel="noopener noreferrer">https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25</a>
 				on [DATE ACCESSED]. Licensed under CC BY 4.0 (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">https://creativecommons.org/licenses/by/4.0/</a>). Data were filtered and reformatted for analysis. Data archived at [your DOI].
 			</blockquote>
 
 			<p><b>For data not saved in an external repository (not recommended), cite each sample type as follows:</b></p>
 			<blockquote>
 				NEON (National Ecological Observatory Network) Biorepository. Mammal Collection (Ear Tissue). Data accessed from
-				<a href="https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25" target="_blank">https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25</a>
+				<a href="../collections/misc/neoncollprofiles.php?collid=25" target="_blank">https://biorepo.neonscience.org/portal/collections/misc/neoncollprofiles.php?collid=25</a>
 				on [DATE ACCESSED]. Licensed under CC BY 4.0 (<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">https://creativecommons.org/licenses/by/4.0/</a>). No changes were made.
 			</blockquote>
 
@@ -103,7 +103,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 			<h4>Physical Sample Citations</h4>
 			<p>NEON samples and specimens involved in published research must be listed in either the main text or supplemental information of any relevant publication. A complete list of samples provided will be included in the Sample Use Agreement to support accurate physical sample citations (see example table below).</p>
-			<p>The occurrenceID or full IGSN ID should be used to refer to samples (e.g., <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">https://doi.org/10.58052/NEON0D0YI</a>, <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">igsn:10.58052/NEON0D0YI</a> or <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">igsn:NEON0D0YI</a>) in manuscript text as well as in any data repositories, such as GenBank. In cases where IGSN ID use is already clearly denoted, the preceding igsn: tag may be excluded. Where possible, all representations of IGSN IDs should be hyperlinked with the IGSN ID’s complete DOI link. 
+			<p>The occurrenceID or full IGSN ID should be used to refer to samples (e.g., <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">https://doi.org/10.58052/NEON0D0YI</a>, <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">igsn:10.58052/NEON0D0YI</a> or <a href="https://doi.org/10.58052/NEON0D0YI" target="_blank" rel="noopener noreferrer">igsn:NEON0D0YI</a>) in manuscript text as well as in any data repositories, such as GenBank. In cases where IGSN ID use is already clearly denoted, the preceding igsn: tag may be excluded. Where possible, all representations of IGSN IDs should be hyperlinked with the IGSN ID’s complete DOI link.
 			Authors should follow the <a href= "https://zenodo.org/records/18854424" tartget="_blank" rel= "nooopener noreferrer"> Earth Science Information Partners guide</a> to publishing open research using physical samples, as well as established conventions for formatting and displaying IGSN IDs as described by <a href="https://ev.igsn.org/resources/using-igsn-in-publications" target="_blank" rel="noopener noreferrer">IGSN e.V.</a> and <a href="https://support.datacite.org/docs/displaying-igsn-ids" target="_blank" rel="noopener noreferrer">DataCite</a> guidelines. The NEON Biorepository can provide additional guidance on specimen citation conventions.</p>
 
 			<table class="citation-table">
@@ -153,7 +153,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 						<td><a href="https://doi.org/10.58052/NEON03BIT" target="_blank" rel="noopener noreferrer">NEON03BIT</a></td>
 						<td><i>Aedes vexans</i></td>
 					</tr>
-			
+
 					<tr>
 						<td rowspan="3">D07</td>
 						<td rowspan="3">Tennessee</td>
@@ -172,7 +172,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 						<td><a href="https://doi.org/10.58052/NEON03HV3" target="_blank" rel="noopener noreferrer">NEON03HV3</a></td>
 						<td><i>Aedes vexans</i></td>
 					</tr>
-			
+
 					<tr>
 						<td rowspan="4">D08</td>
 						<td rowspan="4">Alabama</td>
@@ -196,7 +196,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 						<td><a href="https://doi.org/10.58052/NEON03I6O" target="_blank" rel="noopener noreferrer">NEON03I6O</a></td>
 						<td><i>Aedes vexans</i></td>
 					</tr>
-			
+
 					<tr>
 						<td rowspan="3">D11</td>
 						<td rowspan="3">Texas</td>
@@ -217,8 +217,8 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 					</tr>
 				</tbody>
 			</table>
-			
-						<p><sup>a.</sup> International Geo Sample Number, <a href="https://www.geosamples.org" target="_blank" rel="noopener noreferrer">www.geosamples.org</a></p>
+
+			<p><sup>a.</sup> International Geo Sample Number, <a href="https://www.geosamples.org" target="_blank" rel="noopener noreferrer">www.geosamples.org</a></p>
 
 			<h4>Sample Data Citations</h4>
 			<p>Data associated with physical sample use must also be cited following the <a href="#h.3">Citation Requirements for Data-Only Use</a> as described above.</p>
@@ -238,16 +238,15 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 			<blockquote>
 				<b>Example:</b> Steger, L., NEON (National Ecological Observatory Network) Biorepository. Accessed via NEON (National Ecological Observatory Network) Biorepository Sample Portal [2025-09-23]. B00000021553_1611185823_lg. Photograph.
-				<a href="https://biorepo.neonscience.org/imglib/neon/NEON_MAMC-VSS/00000/B00000021553_1611185823_lg.jpg" target="_blank" rel="noopener noreferrer">https://biorepo.neonscience.org/imglib/neon/NEON_MAMC-VSS/00000/B00000021553_1611185823_lg.jpg</a>
+				<a href="../imglib/neon/NEON_MAMC-VSS/00000/B00000021553_1611185823_lg.jpg" target="_blank" rel="noopener noreferrer">https://biorepo.neonscience.org/imglib/neon/NEON_MAMC-VSS/00000/B00000021553_1611185823_lg.jpg</a>
 			</blockquote>
 
 			<p>A general condition of NEON specimen and sample use is that all raw and derived specimen-level user created image files and associated metadata must be shared with the NEON Biorepository for archive and publication. These images will remain under the ownership of NEON and made available under the Creative Commons Attribution-ShareAlike (CC BY-SA) license.</p>
 		</article>
-		
-	<div style="margin-top: 70px;">
-		<p><em>Last updated May 19, 2026</em></p>	
-	</div>
-	
+
+		<div style="margin-top: 70px;">
+			<p><em>Last updated May 19, 2026</em></p>
+		</div>
 	</div>
 
 </body>

--- a/misc/datasetpublishing.php
+++ b/misc/datasetpublishing.php
@@ -56,7 +56,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 		<article>
 			<h3 class="anchor" id="h.dupjcs7lsdqj">2. Create a NEON Biorepository Published Research Dataset</h3>
-			<p>Lists of samples used in published work can be highlighted and promoted as <a href="https://biorepo.neonscience.org/portal/collections/datasets/publiclist.php" target="_blank" rel="noopener noreferrer">Published Research Dataset</a> within the NEON Biorepository data portal. These datasets and occurrence records therein can be annotated or expanded at any time, and static copies can be downloaded as Darwin Core Archives. These datasets and their associated publications can then also be cited by future researchers, as outlined in relevant dataset pages, <a href="https://biorepo.neonscience.org/portal/collections/datasets/public.php?datasetid=157" target="_blank" rel="noopener noreferrer">such as this one</a>.</p>
+			<p>Lists of samples used in published work can be highlighted and promoted as <a href="../collections/datasets/publiclist.php" target="_blank" rel="noopener noreferrer">Published Research Dataset</a> within the NEON Biorepository data portal. These datasets and occurrence records therein can be annotated or expanded at any time, and static copies can be downloaded as Darwin Core Archives. These datasets and their associated publications can then also be cited by future researchers, as outlined in relevant dataset pages, <a href="../collections/datasets/public.php?datasetid=157" target="_blank" rel="noopener noreferrer">such as this one</a>.</p>
 		</article>
 
 		<article>

--- a/misc/mapsearchtutorial.php
+++ b/misc/mapsearchtutorial.php
@@ -44,7 +44,7 @@ header("Content-Type: text/html; charset=".$CHARSET);
 	  <p>We can use the "Map Search" feature of the NEON Biorepository data portal to visualize and download available NEON samples based on collection, taxon, location, and more. To do so we will:</p>
 
 		<article>
-		  <p>We navigate to <a href="https://biorepo.neonscience.org/portal/collections/map/index.php">Map Search</a> under "Search" in the main menu. This opens a new Google Maps tab.</p>
+		  <p>We navigate to <a href="../collections/map/index.php">Map Search</a> under "Search" in the main menu. This opens a new Google Maps tab.</p>
 		  <figure>
 			<img src="../misc/images/tutorial_45.jpg" alt="Map Search option in menu">
 			<figcaption>Map Search option in menu</figcaption>

--- a/misc/sampleguidelines.php
+++ b/misc/sampleguidelines.php
@@ -13,16 +13,16 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 		h1 {
 			font-size: 2.5rem !important;
 		}
-		
+
 		h4 {
 			font-size: 1.1rem !important;
 		}
-		
+
 		.anchor {
 			font-size: 1.675rem !important;
 			scroll-margin-top: 150px;
 		}
-		
+
 		li {
 			margin-bottom: .2rem;
 		}
@@ -35,9 +35,9 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 	<h1 style="text-align:center;">Sample Use Procedures and Requirements</h1>
 
 	<article>
-		<p>NEON Biorepository samples and specimens and their associated data are available for a wide variety of research and educational purposes. Anyone interested in requesting samples may do so. Most requests are fulfilled at no cost; however, unusually large requests or those requiring substantial additional processing may incur fees. You can browse NEON samples via the <a href="https://biorepo.neonscience.org/portal/collections/misc/browsecollprofiles.php" target="_blank"">Sample Type Browser</a> or <a href="https://biorepo.neonscience.org/portal/neon/search/index.php" target="_blank">Sample Portal</a> and initiate inquiries about using samples in your work by <a href="https://www.neonscience.org/about/contact-neon-biorepository" target="_blank">contacting us</a> directly.</p>
+		<p>NEON Biorepository samples and specimens and their associated data are available for a wide variety of research and educational purposes. Anyone interested in requesting samples may do so. Most requests are fulfilled at no cost; however, unusually large requests or those requiring substantial additional processing may incur fees. You can browse NEON samples via the <a href="../collections/misc/browsecollprofiles.php" target="_blank"">Sample Type Browser</a> or <a href="https://biorepo.neonscience.org/portal/neon/search/index.php" target="_blank">Sample Portal</a> and initiate inquiries about using samples in your work by <a href="https://www.neonscience.org/about/contact-neon-biorepository" target="_blank">contacting us</a> directly.</p>
 	</article>
-		
+
 	<ol>
 		<li><a href="#proposals-and-letters-of-collaboration-or-support">Proposals and Letters</a></li>
 		<li><a href="#visiting-the-neon-biorepository">Visiting the NEON Biorepository</a></li>
@@ -88,10 +88,10 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 			<p>Additional conditions or requirements may be included in the Sample Use Agreement depending on the nature of the requested samples or the proposed research.</p>
 		</article>
-		
+
 		<article>
 			<h2 class="anchor" id="sample-use-policy">Sample Use Policy</h2>
-		
+
 			<p>
 			The NEON Biorepository Sample Use Policy outlines requirements for use, handling, return, and reporting of samples. The policy also indicates that all derived data and media must be shared with the NEON Biorepository for publication in the NEON Sample Portal and that the ownership of images and media resulting from samples will be retained by the NEON Biorepository.
 			<a href="samplepolicy.php">Read the full Sample Use Policy</a>.
@@ -113,7 +113,7 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 
 			<p>Loans are typically approved for 6-12 months. Extensions requested before the current loan period expires will generally be approved except when the samples have been requested by other researchers. Failure to return samples within the approved loan period or to maintain communication regarding their status may affect eligibility for future sample requests. Ordinarily, not more than one-half of the samples from a given sample type, NEON site, year, and taxon may be borrowed at any one time. The remainder may be requested upon the return of the first loan.</p>
 		</article>
-		
+
 		<article>
 			<h2 class="anchor" id="citations">NEON Biorepository Citation Requirements</h2>
 
@@ -121,9 +121,9 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 			Use of NEON Biorepository samples or data must follow established citation and acknowledgment requirements, including acknowledgment language and citation of data, physical samples, associated media, and derived datasets. See the <a href="cite.php">Acknowledging and Citing the NEON Biorepository</a> page for full details.
 			</p>
 		</article>
-		
+
 		<div style="margin-top: 70px;">
-			<p><em>Last updated May 19, 2026</em></p>	
+			<p><em>Last updated May 19, 2026</em></p>
 		</div>
 	</div>
 

--- a/misc/samplepolicy.php
+++ b/misc/samplepolicy.php
@@ -13,16 +13,16 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 		h1 {
 			font-size: 2.5rem !important;
 		}
-		
+
 		h4 {
 			font-size: 1.1rem !important;
 		}
-		
+
 		.anchor {
 			font-size: 1.675rem !important;
 			scroll-margin-top: 150px;
 		}
-		
+
 		li {
 			margin-bottom: 1rem;
 		}
@@ -49,8 +49,8 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 				<li><b>Prior written approval from the NEON Biorepository is required for permission to transfer specimens between institutions.</b></li>
 
 				<!-- <li><b>Loans are made only for the specific research defined in the original request. If alterations to the original request are needed (e.g., sequencing a different gene or using a different method than originally proposed), then written approval must be obtained from the NEON Biorepository.</li> -->
-				
-				<li><b>Researchers using NEON Biorepository samples must provide all resulting sample-associated data to NEON for publication via the <a href="https://biorepo.neonscience.org/portal/neon/search/index.php" target="_blank" rel="noopener noreferrer">NEON Sample Portal</a> for public use within 2 years of sample receipt or upon publication, whichever comes first.</b> Special exceptions regarding data embargos, sensitive data, or extensions may be arranged in writing. This data includes, but is not limited to, species determinations, re-identifications, taxonomic updates, corrections to any existing published data, (raw and derived specimen-level) images and other media files, and links to externally-hosted genetic and genomic sequence data. Instructions for providing these data to the NEON Biorepository will be outlined in the Sample Use Agreement. Guidelines for attribution and licensing of researcher-contributed data default to those listed in the Citation Requirements for <a href="https://biorepo.neonscience.org/portal/misc/cite.php#h.3" target="_blank" rel="noopener noreferrer">Data-Only Use</a> and <a href= "biorepo.org/portal/misc.cite.php#h.5" target="_blank" rel="noopener noreferrer" >Using and Citing Sample Images</a> policies. Future users of requestor-derived data will be encouraged to cite the original publications, which will be linked to associated sample records within the NEON Biorepository Sample Portal. The NEON Biorepository retains ownership of all images and media.</li>
+
+				<li><b>Researchers using NEON Biorepository samples must provide all resulting sample-associated data to NEON for publication via the <a href="../neon/search/index.php" target="_blank" rel="noopener noreferrer">NEON Sample Portal</a> for public use within 2 years of sample receipt or upon publication, whichever comes first.</b> Special exceptions regarding data embargos, sensitive data, or extensions may be arranged in writing. This data includes, but is not limited to, species determinations, re-identifications, taxonomic updates, corrections to any existing published data, (raw and derived specimen-level) images and other media files, and links to externally-hosted genetic and genomic sequence data. Instructions for providing these data to the NEON Biorepository will be outlined in the Sample Use Agreement. Guidelines for attribution and licensing of researcher-contributed data default to those listed in the Citation Requirements for <a href="https://biorepo.neonscience.org/portal/misc/cite.php#h.3" target="_blank" rel="noopener noreferrer">Data-Only Use</a> and <a href= "biorepo.org/portal/misc.cite.php#h.5" target="_blank" rel="noopener noreferrer" >Using and Citing Sample Images</a> policies. Future users of requestor-derived data will be encouraged to cite the original publications, which will be linked to associated sample records within the NEON Biorepository Sample Portal. The NEON Biorepository retains ownership of all images and media.</li>
 
 				<li><b>Researchers must follow all requirements listed in the <a href="cite.php" target="_blank" rel="noopener noreferrer">Acknowledging and Citing the NEON Biorepository</a> policy</b>. Specimens used in publications, reports, or presentations should be listed within the main text and/or supplemental information as outlined in the Sample Use Agreement.</li>
 
@@ -59,11 +59,11 @@ header("Content-Type: text/html; charset=" . $CHARSET);
 				<li><b>Upon receipt of samples, the researcher must review the shipment and sign and return a <a href="documents/sampleReceiptConfirmation.pdf" target="_blank" rel="noopener noreferrer">Sample Receipt Confirmation</a></b> acknowledging receipt of the materials and their condition. The researcher’s institution is responsible for proper handling, storage, and use of all samples while in their possession and for ensuring compliance with the Sample Use Agreement, including maintaining appropriate storage conditions and preventing loss or contamination. The NEON Biorepository must be notified promptly if samples are lost, damaged, or compromised while in the researcher’s possession.</li>
 			</ul>
 
-			<p><b><i>All requests require a mutually developed and signed <a href="sampleguidelines.php#sample-use-agreement">Sample Use Agreement </a> prior to sample processing and shipment.</i></b> The NEON Biorepository reserves the right to deny future sample requests from researchers who do not adhere to this Sample Use Policy or to the terms outlined in a signed Sample Use Agreement.</p> 
+			<p><b><i>All requests require a mutually developed and signed <a href="sampleguidelines.php#sample-use-agreement">Sample Use Agreement </a> prior to sample processing and shipment.</i></b> The NEON Biorepository reserves the right to deny future sample requests from researchers who do not adhere to this Sample Use Policy or to the terms outlined in a signed Sample Use Agreement.</p>
 		</article>
-		
+
 		<div style="margin-top: 70px;">
-			<p><em>Last updated June 9, 2026</em></p>	
+			<p><em>Last updated June 9, 2026</em></p>
 		</div>
 	</div>
 

--- a/misc/samplerequests.php
+++ b/misc/samplerequests.php
@@ -12,7 +12,7 @@ header('Content-Type: text/html; charset=' . $CHARSET);
 		h1 {
 			font-size: 2.5rem !important;
 		}
-		
+
 	</style>
 	</head>
 	<body>
@@ -20,17 +20,17 @@ header('Content-Type: text/html; charset=' . $CHARSET);
 		<div id="innertext">
 			<article>
 				<h1 style="text-align:center;">Requesting Samples</h1>
-	
-				<p>To request samples or learn more about what samples are available for use, you may either browse the <a href="https://biorepo.neonscience.org/portal/collections/misc/browsecollprofiles.php" target="_blank"">Sample Type Browser</a> or <a href="https://biorepo.neonscience.org/portal/neon/search/index.php" target="_blank">NEON Biorepository Sample Portal</a> and initiate inquiries by <a href="https://www.neonscience.org/about/contact-neon-biorepository" target="_blank">contacting us</a> directly. We will follow up within five business days to assist you in identifying appropriate samples and submitting a formal Sample Use Request.</p>
-				
+
+				<p>To request samples or learn more about what samples are available for use, you may either browse the <a href="../collections/misc/browsecollprofiles.php" target="_blank"">Sample Type Browser</a> or <a href="https://biorepo.neonscience.org/portal/neon/search/index.php" target="_blank">NEON Biorepository Sample Portal</a> and initiate inquiries by <a href="https://www.neonscience.org/about/contact-neon-biorepository" target="_blank">contacting us</a> directly. We will follow up within five business days to assist you in identifying appropriate samples and submitting a formal Sample Use Request.</p>
+
 				<a class="link--button link--arrow" href="https://www.neonscience.org/about/contact-neon-biorepository" style="margin-top: 25px;margin-bottom: 25px;">Contact Us to Request Samples <svg width="13px" height="10px" viewBox="0 0 13 10" xmlns="http://www.w3.org/2000/svg"><g class="chevronGroup" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" stroke="#0073CF" stroke-width="2" transform="translate(1.000000, 1.000000)"><path d="M11,4 L7,8" class="bottom"></path><path d="M11,4 L7,0" class="top"></path><path d="M11,4 L0,4" class="line"></path></g></svg></a>
-	
+
 				<p>All requests are evaluated via the <a href="sampleguidelines.php#sample-use-approval-process">Sample Use Approval Process</a>, subject to the <a href="sampleguidelines.php#sample-use-policy">Sample Use Policy</a>. <b><i>All requests require a mutually developed and signed Sample Use Agreement prior to sample processing and shipment or access.</i></b> Researchers should allow approximately two weeks for development and finalization of the Sample Use Agreement.</p>
-	
+
 				<p>The NEON Biorepository aims to fulfill requests of fewer than 100 samples that require no subsampling or additional processing within four weeks of signing a Sample Use Agreement and without any charge. Note that processing times can be much longer when hiring additional NEON Biorepository personnel is required.</p>
-	
+
 				<p>Funding is not required to request or access samples. However, requests requiring substantial effort to fulfill may require funding or service fees. These costs will be estimated by the NEON Biorepository based on the type of request, complexity, and amount of support required. Researchers are encouraged to visit the NEON Biorepository to access samples, and we will provide working space, sample access, and our expertise free of charge.</p>
-				
+
 				<img src="images/loan_process.png" alt="Sample loan process" style="max-width: 100%; height: auto; margin: 1rem 0;">
 			</article>
 		</div>

--- a/neon-react/biorepo_lib/sidebar.json
+++ b/neon-react/biorepo_lib/sidebar.json
@@ -29,7 +29,7 @@
     "links": [
         {
           "name": "NEON Biorepository Sample Portal at ASU",
-          "hash": "https://biorepo.neonscience.org/portal/neon/search/index.php",
+          "hash": "/portal/neon/search/index.php",
           "match": [
                     "neon/search/index.php",
                     "collections/list.php"

--- a/profile/index.php
+++ b/profile/index.php
@@ -9,7 +9,7 @@ if(!empty($THIRD_PARTY_OID_AUTH_ENABLED)){
 use Jumbojett\OpenIDConnectClient;
 
 //neon edit
-if (empty($SYMB_UID)) {
+if (empty($SYMB_UID) && empty($NEON_DEV_MODE)) {
     if (isset($_REQUEST['refurl']) && is_string($_REQUEST['refurl'])) {
         $_SESSION['refurl'] = $_REQUEST['refurl'];
     }


### PR DESCRIPTION
- Add Development Mode authentication toggle to facilitate testing portal functions within a development environment. Inserting "$NEON_DEV_MODE = 1;" into symbini file within your development environment will: 
-- bypass login via Battelle and make use of local portal login.
-- override forwarding to https://neonscience.org resources  
- Convert absolute links to https://neonscience.org to relative link to facilitate testing portal within a development environment without links taking you back to production portal 